### PR TITLE
fix: populate Default column in legacy pretty mode

### DIFF
--- a/src/mkdocs_typer2/pretty.py
+++ b/src/mkdocs_typer2/pretty.py
@@ -120,6 +120,32 @@ def _get_short_help(command: click.core.Command) -> str:
     return short_help.strip() if short_help else ""
 
 
+_PARAM_SUFFIX_RE = re.compile(
+    r"\s+\[(required|default:\s*(?P<default_value>[^\]]+))\]\s*$"
+)
+
+
+def _parse_typer_param_line_description(
+    description: str,
+) -> tuple[str, bool, Optional[str]]:
+    """Strip Typer markdown suffixes like ``[required]`` and ``[default: …]``."""
+    text = description.strip()
+    required = False
+    default: Optional[str] = None
+
+    while True:
+        match = _PARAM_SUFFIX_RE.search(text)
+        if not match:
+            break
+        if match.group(1) == "required":
+            required = True
+        else:
+            default = match.group("default_value").strip()
+        text = text[: match.start()].rstrip()
+
+    return text, required, default
+
+
 def _build_tree_from_click_command(
     command: click.core.Command,
     parent_ctx: Optional[click.Context] = None,
@@ -305,27 +331,27 @@ def parse_markdown_to_tree(content: str) -> CommandNode:
             in_commands_section = True
 
         elif line.startswith("* `") and current_section == "options":
-            # Parse option
-            match = re.match(r"\* `(.*?)`: (.*?)(?:\s+\[(\w+)\])?$", line)
+            match = re.match(r"\* `(.*?)`: (.*)$", line)
             if match:
-                name, desc, modifier = match.groups()
-                option = Option(
-                    name=name,
-                    description=desc.strip(),
-                    required=modifier == "required",
-                    default="no-caps" if "default: no-caps" in desc else None,
+                name, raw_desc = match.groups()
+                desc, required, default = _parse_typer_param_line_description(raw_desc)
+                current_command.options.append(
+                    Option(
+                        name=name,
+                        description=desc,
+                        required=required,
+                        default=default,
+                    )
                 )
-                current_command.options.append(option)
 
         elif line.startswith("* `") and current_section == "arguments":
-            # Parse argument
-            match = re.match(r"\* `(.*?)`: (.*?)(?:\s+\[(\w+)\])?$", line)
+            match = re.match(r"\* `(.*?)`: (.*)$", line)
             if match:
-                name, desc, modifier = match.groups()
-                argument = Argument(
-                    name=name, description=desc.strip(), required=modifier == "required"
+                name, raw_desc = match.groups()
+                desc, required, _default = _parse_typer_param_line_description(raw_desc)
+                current_command.arguments.append(
+                    Argument(name=name, description=desc, required=required)
                 )
-                current_command.arguments.append(argument)
 
         elif line.startswith("* `") and in_commands_section:
             # Parse command name and description

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -298,7 +298,9 @@ $ typer hello [OPTIONS] NAME
     assert len(hello_cmd.arguments) > 0
     assert len(hello_cmd.options) > 0
     assert any(arg.name == "NAME" for arg in hello_cmd.arguments)
-    caps_opt = next(opt for opt in hello_cmd.options if opt.name == "--caps / --no-caps")
+    caps_opt = next(
+        opt for opt in hello_cmd.options if opt.name == "--caps / --no-caps"
+    )
     assert caps_opt.description == "Whether to capitalize the name"
     assert caps_opt.default == "no-caps"
     assert "[default:" not in caps_opt.description

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -10,11 +10,12 @@ from mkdocs_typer2.pretty import (
     CommandEntry,
     CommandNode,
     Option,
-    build_tree_from_click_app,
     _format_option_default,
     _format_option_name,
     _format_usage,
+    _parse_typer_param_line_description,
     _resolve_click_command,
+    build_tree_from_click_app,
     parse_markdown_to_tree,
     tree_to_markdown,
     tree_to_markdown_list,
@@ -134,14 +135,31 @@ def test_option_with_default():
 # mycli
 
 **Options**:
-* `--style`: Output style default: no-caps
+* `--style`: Output style  [default: no-caps]
 """
 
     result = parse_markdown_to_tree(markdown)
 
     assert len(result.options) == 1
     assert result.options[0].name == "--style"
+    assert result.options[0].description == "Output style"
     assert result.options[0].default == "no-caps"
+
+
+def test_parse_typer_param_line_description():
+    desc, required, default = _parse_typer_param_line_description(
+        "Whether to capitalize the name  [default: no-caps]"
+    )
+    assert desc == "Whether to capitalize the name"
+    assert not required
+    assert default == "no-caps"
+
+    desc, required, default = _parse_typer_param_line_description(
+        "The name of the project  [required]"
+    )
+    assert desc == "The name of the project"
+    assert required
+    assert default is None
 
 
 @pytest.mark.parametrize(
@@ -280,7 +298,10 @@ $ typer hello [OPTIONS] NAME
     assert len(hello_cmd.arguments) > 0
     assert len(hello_cmd.options) > 0
     assert any(arg.name == "NAME" for arg in hello_cmd.arguments)
-    assert any(opt.name == "--caps / --no-caps" for opt in hello_cmd.options)
+    caps_opt = next(opt for opt in hello_cmd.options if opt.name == "--caps / --no-caps")
+    assert caps_opt.description == "Whether to capitalize the name"
+    assert caps_opt.default == "no-caps"
+    assert "[default:" not in caps_opt.description
 
 
 def test_parse_markdown_with_commands():
@@ -536,6 +557,18 @@ def test_parse_markdown_with_commands_fallback():
 """
     tree = parse_markdown_to_tree(markdown)
     assert tree.commands[0].name == "foo"
+
+
+def test_legacy_pretty_default_only_in_default_column():
+    markdown = """
+# mycli
+
+**Options**:
+* `--caps / --no-caps`: Whether to capitalize the name  [default: no-caps]
+"""
+    table = tree_to_markdown(parse_markdown_to_tree(markdown))
+    assert "Whether to capitalize the name  [default: no-caps]" not in table
+    assert "`no-caps`" in table
 
 
 def test_parse_markdown_nested_command_without_parent():


### PR DESCRIPTION
## Summary

- Parse Typer markdown option/argument suffixes (`[required]`, `[default: …]`) when building the legacy pretty command tree, instead of relying on a one-off `no-caps` substring check.
- Strip those suffixes from descriptions so defaults appear only in the table Default column, matching native engine behavior.

## Test plan

- [x] `uv run pytest tests/test_pretty.py`
- [x] `uv run pytest` (full suite)
- [x] End-to-end: `typer … utils docs` → `parse_markdown_to_tree` → `tree_to_markdown` shows `no-caps` in Default, not in Description

Fixes #30