### PR TITLE
chore: release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-27
+
+### Fixed
+
+- Native engine docs now show `click.Choice`, `Enum`, and type metvars in option names (e.g. `--mode [a|b|c]`), including Typer 0.26 `FuncParamType` wrappers ([#32](https://github.com/syn54x/mkdocs-typer2/pull/32), [#31](https://github.com/syn54x/mkdocs-typer2/issues/31)).
+- Legacy pretty mode populates the Default column from Typer markdown suffixes (`[default: …]`, `[required]`) instead of leaving defaults in descriptions ([#33](https://github.com/syn54x/mkdocs-typer2/pull/33), [#30](https://github.com/syn54x/mkdocs-typer2/issues/30)).
+
+### Added
+
+- Sample CLI `export` command demonstrating Choice, Enum, type metvars, and custom metavar in generated docs.
+
 ## [0.3.0] - 2026-04-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-typer2"
-version = "0.3.0"
+version = "0.3.1"
 description = "Typer CLI docs for MkDocs (optional) and Zensical via Python-Markdown"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare **0.3.1** for release:

- Bump `version` in `pyproject.toml` to `0.3.1`
- Document fixes merged since `0.3.0` in `CHANGELOG.md`

## Changes in 0.3.1

- **Fixed:** Native engine shows Choice/Enum/type metvars in option names ([#32](https://github.com/syn54x/mkdocs-typer2/pull/32))
- **Fixed:** Legacy pretty mode populates the Default column from Typer markdown suffixes ([#33](https://github.com/syn54x/mkdocs-typer2/pull/33))
- **Added:** Sample CLI `export` command for docs examples

## After merge

1. Create GitHub Release `v0.3.1` (publish) to trigger PyPI upload via `publish.yml`
2. Docs site updates automatically on merge to `main`

## Test plan

- [x] Changelog and version only — no code changes in this PR

Made with [Cursor](https://cursor.com)