### PR TITLE
feat: termynal output mode for the directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `termynal` output mode: render a CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables, enabled per block (`:termynal: true`) or globally (`termynal: true`). The app is introspected in-process (no subprocess) and its colored `--help` is converted to termynal markup; the root command renders first, followed by one block per non-hidden direct subcommand. Requires the optional `[termynal]` extra (`pip install "mkdocs-typer2[termynal]"`); using the mode without it raises a clear install hint ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35)).
+- Termynal options, each available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`): `width`, `scheme`, `dark_bg`, `buttons` (`macos`/`windows`), `prompt`, and `type_delay`/`line_delay`/`start_delay` animation timings. Invalid `scheme`/`buttons` values fall back to their defaults.
+- `CLI (Termynal)` documentation page demonstrating the new mode.
+
 ## [0.3.1] - 2026-05-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `termynal` output mode: render a CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables, enabled per block (`:termynal: true`) or globally (`termynal: true`). The app is introspected in-process (no subprocess) and its colored `--help` is converted to termynal markup; by default only the root command is rendered. Requires the optional `[termynal]` extra (`pip install "mkdocs-typer2[termynal]"`); using the mode without it raises a clear install hint ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35)).
+- Termynal `:command:` directive option: render a specific subcommand's `--help` instead of the root, selected by a space-separated path (e.g. `:command: subapp sub-command`); `:subcommands:` recursion applies relative to it. Block-level only.
 - Termynal options, each available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`): `subcommands` (recursion depth: `0` root only, `N` levels, `-1` full tree), `width`, `scheme`, `dark_bg`, `buttons` (`macos`/`windows`), `prompt`, and `type_delay`/`line_delay`/`start_delay` animation timings. Invalid `scheme`/`buttons` values fall back to their defaults.
 - `CLI (Termynal)` documentation page demonstrating the new mode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Termynal `:command:` directive option: render a specific subcommand's `--help` instead of the root, selected by a space-separated path (e.g. `:command: subapp sub-command`); `:subcommands:` recursion applies relative to it. Block-level only.
 - Termynal options, each available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`): `subcommands` (recursion depth: `0` root only, `N` levels, `-1` full tree), `width`, `scheme`, `dark_bg`, `buttons` (`macos`/`windows`), `prompt`, and `type_delay`/`line_delay`/`start_delay` animation timings. Invalid `scheme`/`buttons` values fall back to their defaults.
 - `CLI (Termynal)` documentation page demonstrating the new mode.
+- Documentation for serving termynal blocks under Zensical: register `termynal.css` / `termynal.js` via `extra_css` / `extra_javascript` (CDN one-liner or self-hosted), since Zensical does not run the `termynal` MkDocs plugin.
 
 ## [0.3.1] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `termynal` output mode: render a CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables, enabled per block (`:termynal: true`) or globally (`termynal: true`). The app is introspected in-process (no subprocess) and its colored `--help` is converted to termynal markup; the root command renders first, followed by one block per non-hidden direct subcommand. Requires the optional `[termynal]` extra (`pip install "mkdocs-typer2[termynal]"`); using the mode without it raises a clear install hint ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35)).
-- Termynal options, each available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`): `width`, `scheme`, `dark_bg`, `buttons` (`macos`/`windows`), `prompt`, and `type_delay`/`line_delay`/`start_delay` animation timings. Invalid `scheme`/`buttons` values fall back to their defaults.
+- `termynal` output mode: render a CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables, enabled per block (`:termynal: true`) or globally (`termynal: true`). The app is introspected in-process (no subprocess) and its colored `--help` is converted to termynal markup; by default only the root command is rendered. Requires the optional `[termynal]` extra (`pip install "mkdocs-typer2[termynal]"`); using the mode without it raises a clear install hint ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35)).
+- Termynal options, each available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`): `subcommands` (recursion depth: `0` root only, `N` levels, `-1` full tree), `width`, `scheme`, `dark_bg`, `buttons` (`macos`/`windows`), `prompt`, and `type_delay`/`line_delay`/`start_delay` animation timings. Invalid `scheme`/`buttons` values fall back to their defaults.
 - `CLI (Termynal)` documentation page demonstrating the new mode.
 
 ## [0.3.1] - 2026-05-27

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 - `:engine:` - `legacy` parses Typer markdown (deprecated). `native` walks Click and renders lists or tables based on `pretty`.
 - `:termynal:` - Set to `true` to render the CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables. The root command is rendered first, followed by one block per direct subcommand. Overrides the global `termynal` setting.
 - `:width:` - Terminal width (in columns) used when capturing `--help` for termynal output. Defaults to `80`.
+- `:scheme:` - Color palette for termynal output. One of `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm`. Invalid values fall back to `xterm` (the default).
+- `:dark_bg:` - Set to `false` to use the scheme's light-background variant. Defaults to `true`.
 
 ### Termynal Output Mode
 
@@ -193,9 +195,9 @@ How it works: the app module is imported and each command's `--help` is rendered
 in-process (forcing rich's terminal output so color is preserved). Hidden
 commands are skipped, matching what `--help` itself shows. The ANSI output is
 converted to inline HTML with [`ansi2html`](https://github.com/pycontribs/ansi2html)
-and wrapped in termynal's `data-ty` markup, which `termynal.js` animates. The
-fork does not import termynal's Python renderer — it emits the markup directly,
-and `tests/test_termynal_contract.py` guards that markup against drift.
+and wrapped in termynal's `data-ty` markup, which `termynal.js` animates. It does
+not import termynal's Python renderer — it emits the markup directly, and
+`tests/test_termynal_contract.py` guards that markup against drift.
 
 Enable it globally via the MkDocs plugin:
 
@@ -204,6 +206,8 @@ plugins:
   - mkdocs-typer2:
       termynal: true
       width: 80
+      scheme: xterm
+      dark_bg: true
 ```
 
 or per block:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 - `:name:` - The name of the CLI. If left blank, your CLI will simply be named `CLI` in your documentation.
 - `:pretty:` - Set to `true` to enable pretty formatting for this specific documentation block, overriding the global setting.
 - `:engine:` - `legacy` parses Typer markdown (deprecated). `native` walks Click and renders lists or tables based on `pretty`.
-- `:termynal:` - Set to `true` to render the CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables. The root command is rendered first, followed by one block per direct subcommand. Overrides the global `termynal` setting.
+- `:termynal:` - Set to `true` to render the CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables. By default only the root command's `--help` is rendered (see `:subcommands:` to include nested commands). Overrides the global `termynal` setting.
+- `:subcommands:` - Recursion depth for termynal output. `0` (default) renders only the root command's `--help`; `1` adds a block per direct subcommand, `2` adds their subcommands, and so on; `-1` renders every level. Hidden commands are skipped at every level.
 - `:width:` - Terminal width (in columns) used when capturing `--help` for termynal output. Defaults to `80`.
 - `:scheme:` - Color palette for termynal output. One of `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm`. Invalid values fall back to `xterm` (the default).
 - `:dark_bg:` - Set to `false` to use the scheme's light-background variant. Defaults to `true`.
@@ -192,7 +193,9 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 Termynal mode introspects the Typer/Click app in-process and emits a faithful,
 colored terminal of what `<cmd> --help` prints. Typer apps (which render help
 through rich) come out colored; plain Click apps render their monochrome help.
-Nothing is executed as a subprocess.
+Nothing is executed as a subprocess. By default only the root command is shown;
+set `:subcommands:` (or `termynal_subcommands`) to a depth to stack its
+subcommands' `--help` below it (`-1` for the full tree).
 
 How it works: the app module is imported and each command's `--help` is rendered
 in-process (forcing rich's terminal output so color is preserved). Hidden
@@ -208,6 +211,7 @@ Enable it globally via the MkDocs plugin:
 plugins:
   - mkdocs-typer2:
       termynal: true
+      termynal_subcommands: 0
       termynal_width: 80
       termynal_scheme: xterm
       termynal_dark_bg: true

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 - `:width:` - Terminal width (in columns) used when capturing `--help` for termynal output. Defaults to `80`.
 - `:scheme:` - Color palette for termynal output. One of `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm`. Invalid values fall back to `xterm` (the default).
 - `:dark_bg:` - Set to `false` to use the scheme's light-background variant. Defaults to `true`.
+- `:buttons:` - Window chrome style for termynal output. One of `macos` (default) or `windows`. Invalid values fall back to `macos`.
+- `:prompt:` - Prompt symbol shown before the `--help` command. Defaults to `$`.
+- `:type_delay:` / `:line_delay:` / `:start_delay:` - Termynal animation timings in milliseconds (per character, per line, before start). Left unset, termynal's own defaults apply.
 
 ### Termynal Output Mode
 
@@ -208,7 +211,14 @@ plugins:
       termynal_width: 80
       termynal_scheme: xterm
       termynal_dark_bg: true
+      termynal_buttons: macos
+      termynal_prompt: "$"
+      # termynal_type_delay / termynal_line_delay / termynal_start_delay (ms)
+      # may also be set; unset, termynal's own animation defaults apply.
 ```
+
+Every block-level option above has a global `termynal_`-prefixed equivalent
+(e.g. `:buttons:` ↔ `termynal_buttons`); the block-level value wins.
 
 or per block:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ engine = "native"
 
 If you share one project between MkDocs and Zensical, keep `mkdocs-typer2` out of `plugins` for the Zensical-focused config (or use separate config files) so the Markdown extension is not applied twice.
 
+#### Termynal assets under Zensical
+
+The `:termynal:` output mode only emits termynal's `data-termynal` markup; the CSS/JS that styles and animates it is shipped separately. Under MkDocs the `termynal` plugin injects them, but **Zensical does not run that plugin**, so the blocks render as unstyled text unless you add the assets yourself.
+
+The simplest way is to point `extra_css` / `extra_javascript` at termynal's assets on a CDN. Pin the version to the `termynal` you installed (`pip show termynal`) so the assets match the markup this extension emits:
+
+**`mkdocs.yml`:**
+
+```yaml
+extra_css:
+  - https://cdn.jsdelivr.net/gh/termynal/termynal.py@0.14.0/termynal/assets/termynal.css
+extra_javascript:
+  - https://cdn.jsdelivr.net/gh/termynal/termynal.py@0.14.0/termynal/assets/termynal.js
+```
+
+**`zensical.toml`:**
+
+```toml
+[project]
+extra_css = ["https://cdn.jsdelivr.net/gh/termynal/termynal.py@0.14.0/termynal/assets/termynal.css"]
+extra_javascript = ["https://cdn.jsdelivr.net/gh/termynal/termynal.py@0.14.0/termynal/assets/termynal.js"]
+```
+
+To self-host instead, copy `termynal.css` / `termynal.js` from the installed `termynal` package's `assets/` directory into your docs tree and reference them by relative path.
+
+Do **not** inline the CSS/JS into page content (Zensical folds raw `<style>` text into the page title/heading). Use `extra_css` / `extra_javascript` so the assets load in the page head/footer as intended.
+
 ## Usage
 
 ### Basic Usage
@@ -255,10 +282,17 @@ each — select it with `:command:`:
   `pip install "mkdocs-typer2[termynal]"`. Using `:termynal:` without it raises a
   clear install hint. ANSI-to-HTML conversion is done with `ansi2html`; the rest
   of mkdocs-typer2 has no termynal dependency.
-- The rendered blocks rely on termynal's CSS/JS being present on the page. Enable
-  the [`termynal` MkDocs plugin](https://github.com/termynal/termynal.py) (or
-  otherwise include `termynal.css` / `termynal.js`), or the blocks will not
-  animate or be styled.
+- The rendered blocks rely on termynal's CSS/JS being present on the page, and
+  how you provide it differs by builder:
+  - **MkDocs:** enable the
+    [`termynal` MkDocs plugin](https://github.com/termynal/termynal.py)
+    (`plugins: [termynal]`); it injects `termynal.css` / `termynal.js`
+    automatically.
+  - **Zensical:** the termynal plugin does not run, so add the assets yourself
+    via `extra_css` / `extra_javascript` — see
+    [Termynal assets under Zensical](#termynal-assets-under-zensical).
+
+  Without the CSS/JS the blocks render as unstyled text.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ I created this plugin because the original plugin was no longer working for me, 
 - Easy to configure and use
 - `pretty` feature for formatting arguments & options as tables
 - `engine` option to select legacy markdown parsing or native Click walking
+- `termynal` output mode that renders `--help` as an animated, colored terminal
 - Global plugin configuration or per-documentation block configuration
 
 ## How It Works
@@ -178,6 +179,53 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 - `:name:` - The name of the CLI. If left blank, your CLI will simply be named `CLI` in your documentation.
 - `:pretty:` - Set to `true` to enable pretty formatting for this specific documentation block, overriding the global setting.
 - `:engine:` - `legacy` parses Typer markdown (deprecated). `native` walks Click and renders lists or tables based on `pretty`.
+- `:termynal:` - Set to `true` to render the CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables. The root command is rendered first, followed by one block per direct subcommand. Overrides the global `termynal` setting.
+- `:width:` - Terminal width (in columns) used when capturing `--help` for termynal output. Defaults to `80`.
+
+### Termynal Output Mode
+
+Termynal mode introspects the Typer/Click app in-process and emits a faithful,
+colored terminal of what `<cmd> --help` prints. Typer apps (which render help
+through rich) come out colored; plain Click apps render their monochrome help.
+Nothing is executed as a subprocess.
+
+How it works: the app module is imported and each command's `--help` is rendered
+in-process (forcing rich's terminal output so color is preserved). Hidden
+commands are skipped, matching what `--help` itself shows. The ANSI output is
+converted to inline HTML with [`ansi2html`](https://github.com/pycontribs/ansi2html)
+and wrapped in termynal's `data-ty` markup, which `termynal.js` animates. The
+fork does not import termynal's Python renderer — it emits the markup directly,
+and `tests/test_termynal_contract.py` guards that markup against drift.
+
+Enable it globally via the MkDocs plugin:
+
+```yaml
+plugins:
+  - mkdocs-typer2:
+      termynal: true
+      width: 80
+```
+
+or per block:
+
+```markdown
+::: mkdocs-typer2
+    :module: my_module.cli
+    :name: mycli
+    :termynal: true
+    :width: 100
+```
+
+**Requirements / caveats:**
+
+- Termynal mode needs the optional `termynal` extra:
+  `pip install "mkdocs-typer2[termynal]"`. Using `:termynal:` without it raises a
+  clear install hint. ANSI-to-HTML conversion is done with `ansi2html`; the rest
+  of mkdocs-typer2 has no termynal dependency.
+- The rendered blocks rely on termynal's CSS/JS being present on the page. Enable
+  the [`termynal` MkDocs plugin](https://github.com/termynal/termynal.py) (or
+  otherwise include `termynal.css` / `termynal.js`), or the blocks will not
+  animate or be styled.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ In your Markdown files, use the `::: mkdocs-typer2` directive to generate docume
 - `:pretty:` - Set to `true` to enable pretty formatting for this specific documentation block, overriding the global setting.
 - `:engine:` - `legacy` parses Typer markdown (deprecated). `native` walks Click and renders lists or tables based on `pretty`.
 - `:termynal:` - Set to `true` to render the CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables. By default only the root command's `--help` is rendered (see `:subcommands:` to include nested commands). Overrides the global `termynal` setting.
-- `:subcommands:` - Recursion depth for termynal output. `0` (default) renders only the root command's `--help`; `1` adds a block per direct subcommand, `2` adds their subcommands, and so on; `-1` renders every level. Hidden commands are skipped at every level.
+- `:command:` - Render a specific subcommand instead of the root. A space-separated path selects nested commands (e.g. `:command: export` renders `<cli> export --help`; `:command: subapp sub-command` goes one level deeper). `:subcommands:` recursion then applies relative to the selected command. Block-level only.
+- `:subcommands:` - Recursion depth for termynal output. `0` (default) renders only the selected command's `--help`; `1` adds a block per direct subcommand, `2` adds their subcommands, and so on; `-1` renders every level. Hidden commands are skipped at every level.
 - `:width:` - Terminal width (in columns) used when capturing `--help` for termynal output. Defaults to `80`.
 - `:scheme:` - Color palette for termynal output. One of `ansi2html`, `dracula`, `mint-terminal`, `osx`, `osx-basic`, `osx-solid-colors`, `solarized`, `xterm`. Invalid values fall back to `xterm` (the default).
 - `:dark_bg:` - Set to `false` to use the scheme's light-background variant. Defaults to `true`.
@@ -222,7 +223,8 @@ plugins:
 ```
 
 Every block-level option above has a global `termynal_`-prefixed equivalent
-(e.g. `:buttons:` ↔ `termynal_buttons`); the block-level value wins.
+(e.g. `:buttons:` ↔ `termynal_buttons`); the block-level value wins. The
+`:command:` selector is block-level only.
 
 or per block:
 
@@ -232,6 +234,19 @@ or per block:
     :name: mycli
     :termynal: true
     :width: 100
+```
+
+To document one subcommand per block — with your own headings and prose around
+each — select it with `:command:`:
+
+```markdown
+## Export
+
+::: mkdocs-typer2
+    :module: my_module.cli
+    :name: mycli
+    :termynal: true
+    :command: export
 ```
 
 **Requirements / caveats:**

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ Enable it globally via the MkDocs plugin:
 plugins:
   - mkdocs-typer2:
       termynal: true
-      width: 80
-      scheme: xterm
-      dark_bg: true
+      termynal_width: 80
+      termynal_scheme: xterm
+      termynal_dark_bg: true
 ```
 
 or per block:

--- a/docs/cli-termynal.md
+++ b/docs/cli-termynal.md
@@ -2,8 +2,8 @@
 
 This page renders the CLI's `--help` as an animated, colored
 [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown
-tables. The root command is rendered first, followed by one block per direct
-subcommand.
+tables. By default only the root command is rendered; the `:subcommands:` option
+sets how many levels of subcommands to stack below it (`-1` for the full tree).
 
 Enable it per block with `:termynal: true` (or globally via the plugin's
 `termynal: true`). The optional `:width:`, `:scheme:`, and `:dark_bg:` options
@@ -13,3 +13,4 @@ control the captured terminal width and color palette.
     :module: mkdocs_typer2.cli.cli
     :name: mkdocs-typer2
     :termynal: true
+    :subcommands: 1

--- a/docs/cli-termynal.md
+++ b/docs/cli-termynal.md
@@ -6,8 +6,10 @@ tables. By default only the root command is rendered; the `:subcommands:` option
 sets how many levels of subcommands to stack below it (`-1` for the full tree).
 
 Enable it per block with `:termynal: true` (or globally via the plugin's
-`termynal: true`). The optional `:width:`, `:scheme:`, and `:dark_bg:` options
-control the captured terminal width and color palette.
+`termynal: true`). Use `:command:` to render a specific subcommand instead of
+the root (e.g. `:command: export`, or `:command: subapp sub-command` for a
+nested one). The optional `:width:`, `:scheme:`, and `:dark_bg:` options control
+the captured terminal width and color palette.
 
 ::: mkdocs-typer2
     :module: mkdocs_typer2.cli.cli

--- a/docs/cli-termynal.md
+++ b/docs/cli-termynal.md
@@ -1,0 +1,15 @@
+# CLI (Termynal)
+
+This page renders the CLI's `--help` as an animated, colored
+[termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown
+tables. The root command is rendered first, followed by one block per direct
+subcommand.
+
+Enable it per block with `:termynal: true` (or globally via the plugin's
+`termynal: true`). The optional `:width:`, `:scheme:`, and `:dark_bg:` options
+control the captured terminal width and color palette.
+
+::: mkdocs-typer2
+    :module: mkdocs_typer2.cli.cli
+    :name: mkdocs-typer2
+    :termynal: true

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -34,6 +34,7 @@ nav:
   - CLI (Legacy): cli.md
   - CLI (Pretty Legacy): cli-pretty-legacy.md
   - CLI (Pretty Native): cli-pretty-native.md
+  - CLI (Termynal): cli-termynal.md
   - CHANGELOG: changelog.md
 
 markdown_extensions:
@@ -54,6 +55,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - termynal
   - mkdocstrings:
       handlers:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
 [project.optional-dependencies]
 mkdocs = ["mkdocs>=1.6.1,<2"]
 zensical = ["zensical>=0.0.30,<1"]
+# Required only for the :termynal: output mode. ansi2html converts the captured
+# --help ANSI to HTML; termynal provides the page CSS/JS (<1 guards its markup).
+termynal = ["ansi2html>=1.8", "termynal>=0.12,<1"]
 
 [project.scripts]
 "mkdocs-typer2" = "mkdocs_typer2.cli.cli:app"
@@ -39,6 +42,9 @@ dev = [
     "markdown-it-py>=3.0.0",
     "pydantic>=2.9.2",
     "zensical>=0.0.30,<1",
+    # so the termynal-mode tests run in CI
+    "ansi2html>=1.8",
+    "termynal>=0.12,<1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -126,7 +126,9 @@ class TyperProcessor(BlockProcessor):
             scheme=_directive_value(block, "scheme") or base.scheme,
             dark_bg=_as_bool(_directive_value(block, "dark_bg"), base.dark_bg),
             buttons=_directive_value(block, "buttons") or base.buttons,
-            prompt=_directive_value(block, "prompt") or base.prompt,
+            # Capture the rest of the line so a multi-word prompt (e.g. ``my $``)
+            # is kept whole rather than truncated at the first token.
+            prompt=_directive_line(block, "prompt") or base.prompt,
             type_delay=_as_int(_directive_value(block, "type_delay"), base.type_delay),
             line_delay=_as_int(_directive_value(block, "line_delay"), base.line_delay),
             start_delay=_as_int(

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -46,14 +46,15 @@ class TyperExtension(markdown.Extension):
         pretty: bool | None = None,
         engine: str = "legacy",
         termynal: bool = False,
-        width: int = 80,
-        scheme: str = "xterm",
-        dark_bg: bool = True,
-        buttons: str = "macos",
-        prompt: str = "$",
-        type_delay: int | None = None,
-        line_delay: int | None = None,
-        start_delay: int | None = None,
+        width: int = TermynalOptions.width,
+        scheme: str = TermynalOptions.scheme,
+        dark_bg: bool = TermynalOptions.dark_bg,
+        buttons: str = TermynalOptions.buttons,
+        prompt: str = TermynalOptions.prompt,
+        type_delay: int | None = TermynalOptions.type_delay,
+        line_delay: int | None = TermynalOptions.line_delay,
+        start_delay: int | None = TermynalOptions.start_delay,
+        subcommands: int = TermynalOptions.subcommands,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -71,6 +72,7 @@ class TyperExtension(markdown.Extension):
             type_delay=type_delay,
             line_delay=line_delay,
             start_delay=start_delay,
+            subcommands=subcommands,
         )
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
@@ -119,6 +121,9 @@ class TyperProcessor(BlockProcessor):
             line_delay=_as_int(_directive_value(block, "line_delay"), base.line_delay),
             start_delay=_as_int(
                 _directive_value(block, "start_delay"), base.start_delay
+            ),
+            subcommands=_as_int(
+                _directive_value(block, "subcommands"), base.subcommands
             ),
         )
 

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -19,6 +19,16 @@ def _directive_value(block: str, key: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _directive_line(block: str, key: str) -> str | None:
+    """Like ``_directive_value`` but captures the rest of the line.
+
+    Used for values that may contain spaces, such as a ``:command:`` path
+    (``plot sub``).
+    """
+    match = re.search(rf":{key}:\s*(.+)", block)
+    return match.group(1).strip() if match else None
+
+
 def _as_bool(value: str | None, default: bool) -> bool:
     if value is None:
         return default
@@ -144,7 +154,10 @@ class TyperProcessor(BlockProcessor):
         use_termynal = _as_bool(_directive_value(block, "termynal"), self.termynal)
         if use_termynal:
             html = render_termynal_html(
-                module, name, self._resolve_termynal_options(block)
+                module,
+                name,
+                self._resolve_termynal_options(block),
+                command=_directive_line(block, "command") or "",
             )
             placeholder = self.parser.md.htmlStash.store(html)
             div = etree.SubElement(parent, "div")

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -15,15 +15,29 @@ from .pretty import (
 
 class TyperExtension(markdown.Extension):
     def __init__(
-        self, *args, pretty: bool | None = None, engine: str = "legacy", **kwargs
+        self,
+        *args,
+        pretty: bool | None = None,
+        engine: str = "legacy",
+        termynal: bool = False,
+        width: int = 80,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.pretty = pretty
         self.engine = engine
+        self.termynal = termynal
+        self.width = width
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
         md.parser.blockprocessors.register(
-            TyperProcessor(md.parser, pretty=self.pretty, engine=self.engine),
+            TyperProcessor(
+                md.parser,
+                pretty=self.pretty,
+                engine=self.engine,
+                termynal=self.termynal,
+                width=self.width,
+            ),
             "typer",
             175,
         )
@@ -31,11 +45,19 @@ class TyperExtension(markdown.Extension):
 
 class TyperProcessor(BlockProcessor):
     def __init__(
-        self, *args, pretty: bool | None = None, engine: str = "legacy", **kwargs
+        self,
+        *args,
+        pretty: bool | None = None,
+        engine: str = "legacy",
+        termynal: bool = False,
+        width: int = 80,
+        **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.pretty = pretty
         self.engine = engine
+        self.termynal = termynal
+        self.width = width
 
     def test(self, parent, block):
         return block.strip().startswith(":::") and "mkdocs-typer2" in block
@@ -53,6 +75,32 @@ class TyperProcessor(BlockProcessor):
 
         module = module_match.group(1)
         name = name_match.group(1) if name_match else ""
+
+        termynal_match = re.search(r":termynal:\s*(\S+)", block)
+        width_match = re.search(r":width:\s*(\S+)", block)
+        use_termynal = self.termynal
+        if termynal_match:
+            value = termynal_match.group(1).lower()
+            if value in ["true", "1", "yes"]:
+                use_termynal = True
+            elif value in ["false", "0", "no"]:
+                use_termynal = False
+        width = self.width
+        if width_match:
+            try:
+                width = int(width_match.group(1))
+            except ValueError:
+                pass
+
+        if use_termynal:
+            from .termynal_render import render_termynal_html
+
+            html = render_termynal_html(module, name, width=width)
+            placeholder = self.parser.md.htmlStash.store(html)
+            div = etree.SubElement(parent, "div")
+            div.set("class", "termynal-typer-docs")
+            div.text = placeholder
+            return True
 
         # Determine if pretty formatting should be used
         # Block-level setting overrides global setting if present

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -11,6 +11,32 @@ from .pretty import (
     tree_to_markdown,
     tree_to_markdown_list,
 )
+from .termynal_render import TermynalOptions, render_termynal_html
+
+
+def _directive_value(block: str, key: str) -> str | None:
+    match = re.search(rf":{key}:\s*(\S+)", block)
+    return match.group(1) if match else None
+
+
+def _as_bool(value: str | None, default: bool) -> bool:
+    if value is None:
+        return default
+    lowered = value.lower()
+    if lowered in ("true", "1", "yes"):
+        return True
+    if lowered in ("false", "0", "no"):
+        return False
+    return default
+
+
+def _as_int(value: str | None, default: int | None) -> int | None:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
 
 
 class TyperExtension(markdown.Extension):
@@ -23,15 +49,29 @@ class TyperExtension(markdown.Extension):
         width: int = 80,
         scheme: str = "xterm",
         dark_bg: bool = True,
+        buttons: str = "macos",
+        prompt: str = "$",
+        type_delay: int | None = None,
+        line_delay: int | None = None,
+        start_delay: int | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.pretty = pretty
         self.engine = engine
         self.termynal = termynal
-        self.width = width
-        self.scheme = scheme
-        self.dark_bg = dark_bg
+        # Termynal render options are bundled so they thread through as one
+        # object instead of a kwarg list duplicated across Extension/Processor.
+        self.termynal_options = TermynalOptions(
+            width=width,
+            scheme=scheme,
+            dark_bg=dark_bg,
+            buttons=buttons,
+            prompt=prompt,
+            type_delay=type_delay,
+            line_delay=line_delay,
+            start_delay=start_delay,
+        )
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
         md.parser.blockprocessors.register(
@@ -40,9 +80,7 @@ class TyperExtension(markdown.Extension):
                 pretty=self.pretty,
                 engine=self.engine,
                 termynal=self.termynal,
-                width=self.width,
-                scheme=self.scheme,
-                dark_bg=self.dark_bg,
+                options=self.termynal_options,
             ),
             "typer",
             175,
@@ -56,21 +94,33 @@ class TyperProcessor(BlockProcessor):
         pretty: bool | None = None,
         engine: str = "legacy",
         termynal: bool = False,
-        width: int = 80,
-        scheme: str = "xterm",
-        dark_bg: bool = True,
+        options: TermynalOptions | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.pretty = pretty
         self.engine = engine
         self.termynal = termynal
-        self.width = width
-        self.scheme = scheme
-        self.dark_bg = dark_bg
+        self.options = options or TermynalOptions()
 
     def test(self, parent, block):
         return block.strip().startswith(":::") and "mkdocs-typer2" in block
+
+    def _resolve_termynal_options(self, block: str) -> TermynalOptions:
+        """Build per-block options from the globals plus directive overrides."""
+        base = self.options
+        return TermynalOptions(
+            width=_as_int(_directive_value(block, "width"), base.width),
+            scheme=_directive_value(block, "scheme") or base.scheme,
+            dark_bg=_as_bool(_directive_value(block, "dark_bg"), base.dark_bg),
+            buttons=_directive_value(block, "buttons") or base.buttons,
+            prompt=_directive_value(block, "prompt") or base.prompt,
+            type_delay=_as_int(_directive_value(block, "type_delay"), base.type_delay),
+            line_delay=_as_int(_directive_value(block, "line_delay"), base.line_delay),
+            start_delay=_as_int(
+                _directive_value(block, "start_delay"), base.start_delay
+            ),
+        )
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
@@ -86,41 +136,10 @@ class TyperProcessor(BlockProcessor):
         module = module_match.group(1)
         name = name_match.group(1) if name_match else ""
 
-        termynal_match = re.search(r":termynal:\s*(\S+)", block)
-        width_match = re.search(r":width:\s*(\S+)", block)
-        scheme_match = re.search(r":scheme:\s*(\S+)", block)
-        dark_bg_match = re.search(r":dark_bg:\s*(\S+)", block)
-        use_termynal = self.termynal
-        if termynal_match:
-            value = termynal_match.group(1).lower()
-            if value in ["true", "1", "yes"]:
-                use_termynal = True
-            elif value in ["false", "0", "no"]:
-                use_termynal = False
-        width = self.width
-        if width_match:
-            try:
-                width = int(width_match.group(1))
-            except ValueError:
-                pass
-        scheme = scheme_match.group(1) if scheme_match else self.scheme
-        dark_bg = self.dark_bg
-        if dark_bg_match:
-            dark_bg_value = dark_bg_match.group(1).lower()
-            if dark_bg_value in ["true", "1", "yes"]:
-                dark_bg = True
-            elif dark_bg_value in ["false", "0", "no"]:
-                dark_bg = False
-
+        use_termynal = _as_bool(_directive_value(block, "termynal"), self.termynal)
         if use_termynal:
-            from .termynal_render import render_termynal_html
-
             html = render_termynal_html(
-                module,
-                name,
-                width=width,
-                ansi_scheme=scheme,
-                ansi_dark_bg=dark_bg,
+                module, name, self._resolve_termynal_options(block)
             )
             placeholder = self.parser.md.htmlStash.store(html)
             div = etree.SubElement(parent, "div")

--- a/src/mkdocs_typer2/markdown.py
+++ b/src/mkdocs_typer2/markdown.py
@@ -21,6 +21,8 @@ class TyperExtension(markdown.Extension):
         engine: str = "legacy",
         termynal: bool = False,
         width: int = 80,
+        scheme: str = "xterm",
+        dark_bg: bool = True,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -28,6 +30,8 @@ class TyperExtension(markdown.Extension):
         self.engine = engine
         self.termynal = termynal
         self.width = width
+        self.scheme = scheme
+        self.dark_bg = dark_bg
 
     def extendMarkdown(self, md: markdown.Markdown) -> None:
         md.parser.blockprocessors.register(
@@ -37,6 +41,8 @@ class TyperExtension(markdown.Extension):
                 engine=self.engine,
                 termynal=self.termynal,
                 width=self.width,
+                scheme=self.scheme,
+                dark_bg=self.dark_bg,
             ),
             "typer",
             175,
@@ -51,6 +57,8 @@ class TyperProcessor(BlockProcessor):
         engine: str = "legacy",
         termynal: bool = False,
         width: int = 80,
+        scheme: str = "xterm",
+        dark_bg: bool = True,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -58,6 +66,8 @@ class TyperProcessor(BlockProcessor):
         self.engine = engine
         self.termynal = termynal
         self.width = width
+        self.scheme = scheme
+        self.dark_bg = dark_bg
 
     def test(self, parent, block):
         return block.strip().startswith(":::") and "mkdocs-typer2" in block
@@ -78,6 +88,8 @@ class TyperProcessor(BlockProcessor):
 
         termynal_match = re.search(r":termynal:\s*(\S+)", block)
         width_match = re.search(r":width:\s*(\S+)", block)
+        scheme_match = re.search(r":scheme:\s*(\S+)", block)
+        dark_bg_match = re.search(r":dark_bg:\s*(\S+)", block)
         use_termynal = self.termynal
         if termynal_match:
             value = termynal_match.group(1).lower()
@@ -91,11 +103,25 @@ class TyperProcessor(BlockProcessor):
                 width = int(width_match.group(1))
             except ValueError:
                 pass
+        scheme = scheme_match.group(1) if scheme_match else self.scheme
+        dark_bg = self.dark_bg
+        if dark_bg_match:
+            dark_bg_value = dark_bg_match.group(1).lower()
+            if dark_bg_value in ["true", "1", "yes"]:
+                dark_bg = True
+            elif dark_bg_value in ["false", "0", "no"]:
+                dark_bg = False
 
         if use_termynal:
             from .termynal_render import render_termynal_html
 
-            html = render_termynal_html(module, name, width=width)
+            html = render_termynal_html(
+                module,
+                name,
+                width=width,
+                ansi_scheme=scheme,
+                ansi_dark_bg=dark_bg,
+            )
             placeholder = self.parser.md.htmlStash.store(html)
             div = etree.SubElement(parent, "div")
             div.set("class", "termynal-typer-docs")

--- a/src/mkdocs_typer2/plugin.py
+++ b/src/mkdocs_typer2/plugin.py
@@ -30,6 +30,26 @@ class MkdocsTyper(BasePlugin):
             "termynal_dark_bg",
             config_options.Type(bool, default=True),
         ),
+        (
+            "termynal_buttons",
+            config_options.Type(str, default="macos"),
+        ),
+        (
+            "termynal_prompt",
+            config_options.Type(str, default="$"),
+        ),
+        (
+            "termynal_type_delay",
+            config_options.Optional(config_options.Type(int)),
+        ),
+        (
+            "termynal_line_delay",
+            config_options.Optional(config_options.Type(int)),
+        ),
+        (
+            "termynal_start_delay",
+            config_options.Optional(config_options.Type(int)),
+        ),
     )
 
     def on_config(self, config, **kwargs) -> dict:
@@ -41,6 +61,11 @@ class MkdocsTyper(BasePlugin):
                 width=self.config.get("termynal_width", 80),
                 scheme=self.config.get("termynal_scheme", "xterm"),
                 dark_bg=self.config.get("termynal_dark_bg", True),
+                buttons=self.config.get("termynal_buttons", "macos"),
+                prompt=self.config.get("termynal_prompt", "$"),
+                type_delay=self.config.get("termynal_type_delay"),
+                line_delay=self.config.get("termynal_line_delay"),
+                start_delay=self.config.get("termynal_start_delay"),
             )
         )
         return config

--- a/src/mkdocs_typer2/plugin.py
+++ b/src/mkdocs_typer2/plugin.py
@@ -14,6 +14,14 @@ class MkdocsTyper(BasePlugin):
             "engine",
             config_options.Type(str, default="legacy"),
         ),
+        (
+            "termynal",
+            config_options.Type(bool, default=False),
+        ),
+        (
+            "width",
+            config_options.Type(int, default=80),
+        ),
     )
 
     def on_config(self, config, **kwargs) -> dict:
@@ -21,6 +29,8 @@ class MkdocsTyper(BasePlugin):
             makeExtension(
                 pretty=self.config.get("pretty", False),
                 engine=self.config.get("engine", "legacy"),
+                termynal=self.config.get("termynal", False),
+                width=self.config.get("width", 80),
             )
         )
         return config

--- a/src/mkdocs_typer2/plugin.py
+++ b/src/mkdocs_typer2/plugin.py
@@ -19,15 +19,15 @@ class MkdocsTyper(BasePlugin):
             config_options.Type(bool, default=False),
         ),
         (
-            "width",
+            "termynal_width",
             config_options.Type(int, default=80),
         ),
         (
-            "scheme",
+            "termynal_scheme",
             config_options.Type(str, default="xterm"),
         ),
         (
-            "dark_bg",
+            "termynal_dark_bg",
             config_options.Type(bool, default=True),
         ),
     )
@@ -38,9 +38,9 @@ class MkdocsTyper(BasePlugin):
                 pretty=self.config.get("pretty", False),
                 engine=self.config.get("engine", "legacy"),
                 termynal=self.config.get("termynal", False),
-                width=self.config.get("width", 80),
-                scheme=self.config.get("scheme", "xterm"),
-                dark_bg=self.config.get("dark_bg", True),
+                width=self.config.get("termynal_width", 80),
+                scheme=self.config.get("termynal_scheme", "xterm"),
+                dark_bg=self.config.get("termynal_dark_bg", True),
             )
         )
         return config

--- a/src/mkdocs_typer2/plugin.py
+++ b/src/mkdocs_typer2/plugin.py
@@ -22,6 +22,14 @@ class MkdocsTyper(BasePlugin):
             "width",
             config_options.Type(int, default=80),
         ),
+        (
+            "scheme",
+            config_options.Type(str, default="xterm"),
+        ),
+        (
+            "dark_bg",
+            config_options.Type(bool, default=True),
+        ),
     )
 
     def on_config(self, config, **kwargs) -> dict:
@@ -31,6 +39,8 @@ class MkdocsTyper(BasePlugin):
                 engine=self.config.get("engine", "legacy"),
                 termynal=self.config.get("termynal", False),
                 width=self.config.get("width", 80),
+                scheme=self.config.get("scheme", "xterm"),
+                dark_bg=self.config.get("dark_bg", True),
             )
         )
         return config

--- a/src/mkdocs_typer2/plugin.py
+++ b/src/mkdocs_typer2/plugin.py
@@ -2,6 +2,7 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
 
 from .markdown import makeExtension
+from .termynal_render import TermynalOptions
 
 
 class MkdocsTyper(BasePlugin):
@@ -20,23 +21,23 @@ class MkdocsTyper(BasePlugin):
         ),
         (
             "termynal_width",
-            config_options.Type(int, default=80),
+            config_options.Type(int, default=TermynalOptions.width),
         ),
         (
             "termynal_scheme",
-            config_options.Type(str, default="xterm"),
+            config_options.Type(str, default=TermynalOptions.scheme),
         ),
         (
             "termynal_dark_bg",
-            config_options.Type(bool, default=True),
+            config_options.Type(bool, default=TermynalOptions.dark_bg),
         ),
         (
             "termynal_buttons",
-            config_options.Type(str, default="macos"),
+            config_options.Type(str, default=TermynalOptions.buttons),
         ),
         (
             "termynal_prompt",
-            config_options.Type(str, default="$"),
+            config_options.Type(str, default=TermynalOptions.prompt),
         ),
         (
             "termynal_type_delay",
@@ -50,22 +51,27 @@ class MkdocsTyper(BasePlugin):
             "termynal_start_delay",
             config_options.Optional(config_options.Type(int)),
         ),
+        (
+            "termynal_subcommands",
+            config_options.Type(int, default=TermynalOptions.subcommands),
+        ),
     )
 
     def on_config(self, config, **kwargs) -> dict:
         config["markdown_extensions"].append(
             makeExtension(
-                pretty=self.config.get("pretty", False),
-                engine=self.config.get("engine", "legacy"),
-                termynal=self.config.get("termynal", False),
-                width=self.config.get("termynal_width", 80),
-                scheme=self.config.get("termynal_scheme", "xterm"),
-                dark_bg=self.config.get("termynal_dark_bg", True),
-                buttons=self.config.get("termynal_buttons", "macos"),
-                prompt=self.config.get("termynal_prompt", "$"),
-                type_delay=self.config.get("termynal_type_delay"),
-                line_delay=self.config.get("termynal_line_delay"),
-                start_delay=self.config.get("termynal_start_delay"),
+                pretty=self.config["pretty"],
+                engine=self.config["engine"],
+                termynal=self.config["termynal"],
+                width=self.config["termynal_width"],
+                scheme=self.config["termynal_scheme"],
+                dark_bg=self.config["termynal_dark_bg"],
+                buttons=self.config["termynal_buttons"],
+                prompt=self.config["termynal_prompt"],
+                type_delay=self.config["termynal_type_delay"],
+                line_delay=self.config["termynal_line_delay"],
+                start_delay=self.config["termynal_start_delay"],
+                subcommands=self.config["termynal_subcommands"],
             )
         )
         return config

--- a/src/mkdocs_typer2/pretty.py
+++ b/src/mkdocs_typer2/pretty.py
@@ -36,19 +36,24 @@ class CommandNode(BaseModel):
     commands: List[CommandEntry] = Field(default_factory=list)
 
 
-def build_tree_from_click_app(module: str, name: str) -> CommandNode:
+def resolve_click_command(module: str, name: str) -> click.core.Command:
+    """Import ``module`` and resolve its Typer/Click app to a Click command.
+
+    Uses the attribute named ``name`` when given, otherwise falls back to a
+    module-level ``app``. Shared by the native engine and termynal output mode.
+    """
     module_ref = importlib.import_module(module)
-    app = None
-    display_name = None
-    if name:
-        display_name = name
-        app = getattr(module_ref, name, None)
+    app = getattr(module_ref, name, None) if name else None
     if app is None:
         app = getattr(module_ref, "app", None)
     if app is None:
         raise ValueError(f"Unable to resolve Typer app from module '{module}'.")
-    command = _resolve_click_command(app)
-    return _build_tree_from_click_command(command, display_name=display_name)
+    return _resolve_click_command(app)
+
+
+def build_tree_from_click_app(module: str, name: str) -> CommandNode:
+    command = resolve_click_command(module, name)
+    return _build_tree_from_click_command(command, display_name=name or None)
 
 
 def _is_click_group(command: object) -> bool:

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -4,6 +4,7 @@ See the "Termynal Output Mode" section of the README for how this works and the
 coupling to termynal's markup contract.
 """
 
+import contextlib
 import io
 from dataclasses import dataclass, replace
 from typing import Dict, List, Literal, Optional, Tuple, get_args
@@ -146,33 +147,62 @@ def _termynal_block_html(
     )
 
 
-def _colored_help(command: click.core.Command, info_name: str, width: int = 80) -> str:
-    """Return the command's ``--help`` text, colored when the app uses rich."""
-    formatter = None
-    buf = io.StringIO()
+#: Name of the private typer factory we swap to capture colored ``--help``.
+#: Typer exposes no public injection point (see ``_colored_help``), so this is
+#: guarded by ``test_typer_rich_console_hook_present`` in the contract tests.
+TYPER_RICH_CONSOLE_HOOK = "_get_rich_console"
 
+
+def _colored_help(command: click.core.Command, info_name: str, width: int = 80) -> str:
+    """Return the command's ``--help`` text, colored when the app uses rich.
+
+    Typer has no public API to render colored ``--help`` to a string: its
+    ``rich_format_help()`` hardcodes ``console = _get_rich_console()`` with no
+    console/file parameter to inject (``CliRunner`` drops rich color, and the
+    env-var knobs are import-time + process-global). So we swap that private
+    factory for a buffer-backed ``Console``.
+
+    If that private hook ever disappears (a future typer rename), we degrade
+    safely: ``format_help`` runs with stdout redirected into the same buffer, so
+    its output is captured monochrome instead of leaking to the console or
+    crashing the build. ``test_typer_rich_console_hook_present`` fails loudly in
+    CI when the hook is gone, and the colored-render test catches the silent
+    drop to monochrome.
+    """
     import typer.rich_utils as ru
     from rich.console import Console
 
-    original = ru._get_rich_console
-    ru._get_rich_console = lambda stderr=False: Console(  # noqa: ARG005
-        force_terminal=True,
-        color_system="standard",
-        width=width,
-        file=buf,
-        highlight=False,
-    )
-    try:
-        ctx = click.Context(command, info_name=info_name)
-        formatter = ctx.make_formatter()
-        command.format_help(ctx, formatter)
-    finally:
-        ru._get_rich_console = original
+    buf = io.StringIO()
+    ctx = click.Context(command, info_name=info_name)
+    formatter = ctx.make_formatter()
+
+    original = getattr(ru, TYPER_RICH_CONSOLE_HOOK, None)
+    if original is not None:
+        setattr(
+            ru,
+            TYPER_RICH_CONSOLE_HOOK,
+            lambda stderr=False: Console(  # noqa: ARG005
+                force_terminal=True,
+                color_system="standard",
+                width=width,
+                file=buf,
+                highlight=False,
+            ),
+        )
+        try:
+            command.format_help(ctx, formatter)
+        finally:
+            setattr(ru, TYPER_RICH_CONSOLE_HOOK, original)
+    else:
+        # Hook gone: render without it, but redirect stdout so any rich output
+        # that bypasses our buffer is captured (monochrome) rather than leaked.
+        with contextlib.redirect_stdout(buf):
+            command.format_help(ctx, formatter)
 
     rich_text = buf.getvalue()
     if rich_text.strip():
         return rich_text
-    return formatter.getvalue() if formatter is not None else ""
+    return formatter.getvalue()
 
 
 def _one_block(

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -247,24 +247,53 @@ def _subcommand_blocks(
     return blocks
 
 
+def _select_command(root: click.core.Command, path: str) -> click.core.Command:
+    """Walk ``path`` (space-separated subcommand names) down from ``root``.
+
+    ``"plot"`` selects the ``plot`` subcommand; ``"plot sub"`` selects ``sub``
+    under it. Explicit selection renders the command even if it is hidden.
+    """
+    command = root
+    for part in path.split():
+        commands = getattr(command, "commands", None)
+        if not isinstance(commands, dict) or part not in commands:
+            raise ValueError(
+                f"Unknown termynal :command: path {path!r}: "
+                f"{command.name or 'the root command'!r} has no subcommand "
+                f"{part!r}."
+            )
+        command = commands[part]
+    return command
+
+
 def render_termynal_html(
     module: str,
     name: str,
     options: Optional[TermynalOptions] = None,
+    *,
+    command: str = "",
 ) -> str:
     """Render ``module``'s app help as one or more termynal HTML blocks.
 
-    The root command's ``--help`` is always rendered as a single block. Each
-    extra level of ``options.subcommands`` adds a stacked block per non-hidden
-    subcommand at that depth; at the default of 0 only the root block is emitted
-    (matching a bare ``<cmd> --help``).
+    By default the resolved app's ``--help`` is rendered as a single block. When
+    ``command`` is given (a space-separated subcommand path, e.g. ``"plot"`` or
+    ``"plot sub"``), that subcommand is selected as the block's command instead,
+    and ``options.subcommands`` recursion applies relative to it. Each extra
+    level of ``options.subcommands`` adds a stacked block per non-hidden
+    subcommand at that depth; at the default of 0 only the selected block is
+    emitted (matching a bare ``<cmd> --help``).
     """
     options = _normalized(options or TermynalOptions())
 
-    command = resolve_click_command(module, name)
-    display = name or command.name or ""
+    root = resolve_click_command(module, name)
+    display = name or root.name or ""
 
-    blocks: List[str] = [_one_block(command, display, options)]
-    blocks.extend(_subcommand_blocks(command, display, options, options.subcommands))
+    selected = root
+    if command:
+        selected = _select_command(root, command)
+        display = f"{display} {command}".strip()
+
+    blocks: List[str] = [_one_block(selected, display, options)]
+    blocks.extend(_subcommand_blocks(selected, display, options, options.subcommands))
 
     return "\n".join(blocks)

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -4,13 +4,12 @@ See the "Termynal Output Mode" section of the README for how this works and the
 coupling to termynal's markup contract.
 """
 
-import importlib
 import io
 from typing import List
 
 import click
 
-from .pretty import _is_click_group, _resolve_click_command
+from .pretty import _is_click_group, resolve_click_command
 
 ANSI_SCHEMES = (
     "ansi2html",
@@ -110,16 +109,6 @@ def _colored_help(command: click.core.Command, info_name: str, width: int = 80) 
     return formatter.getvalue() if formatter is not None else ""
 
 
-def _resolve_app(module: str, name: str) -> click.core.Command:
-    module_ref = importlib.import_module(module)
-    app = getattr(module_ref, name, None) if name else None
-    if app is None:
-        app = getattr(module_ref, "app", None)
-    if app is None:
-        raise ValueError(f"Unable to resolve Typer/Click app from module '{module}'.")
-    return _resolve_click_command(app)
-
-
 def _one_block(
     command: click.core.Command,
     info_name: str,
@@ -159,7 +148,7 @@ def render_termynal_html(
     if ansi_scheme not in ANSI_SCHEMES:
         ansi_scheme = DEFAULT_ANSI_SCHEME
 
-    command = _resolve_app(module, name)
+    command = resolve_click_command(module, name)
     display = name or command.name or ""
 
     blocks: List[str] = [

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -58,6 +58,10 @@ class TermynalOptions:
 
     ``scheme`` and ``buttons`` are validated at render time; an out-of-domain
     value (directive input is free text) falls back to its default.
+
+    ``subcommands`` is a recursion depth: 0 renders only the root command's
+    ``--help`` (the default), 1 adds its direct subcommands, 2 adds their
+    subcommands, and so on; -1 renders every level (the full tree).
     """
 
     width: int = 80
@@ -68,6 +72,7 @@ class TermynalOptions:
     type_delay: Optional[int] = None
     line_delay: Optional[int] = None
     start_delay: Optional[int] = None
+    subcommands: int = 0
 
 
 def _html_escape(text: str) -> str:
@@ -192,25 +197,67 @@ def _one_block(
 
 
 def _normalized(options: TermynalOptions) -> TermynalOptions:
-    """Coerce an out-of-domain ``scheme``/``buttons`` back to its default."""
+    """Coerce out-of-domain ``scheme``/``buttons``/``width``/``subcommands``.
+
+    ``scheme``/``buttons`` are free-text directive input, so an unknown value
+    falls back to its default; ``width`` is floored at 1 since a non-positive
+    value would make ``rich.Console`` raise or render nothing; ``subcommands``
+    (a recursion depth) keeps any negative value as the -1 "all levels" sentinel.
+    """
     scheme = options.scheme if options.scheme in ANSI_SCHEMES else DEFAULT_ANSI_SCHEME
     buttons = options.buttons if options.buttons in BUTTONS else DEFAULT_BUTTONS
-    if scheme == options.scheme and buttons == options.buttons:
+    width = max(1, options.width)
+    subcommands = options.subcommands if options.subcommands >= 0 else -1
+    if (
+        scheme == options.scheme
+        and buttons == options.buttons
+        and width == options.width
+        and subcommands == options.subcommands
+    ):
         return options
-    return replace(options, scheme=scheme, buttons=buttons)
+    return replace(
+        options, scheme=scheme, buttons=buttons, width=width, subcommands=subcommands
+    )
+
+
+def _subcommand_blocks(
+    command: click.core.Command,
+    display: str,
+    options: TermynalOptions,
+    depth: int,
+) -> List[str]:
+    """Render up to ``depth`` levels of non-hidden subcommands, depth-first.
+
+    Each subcommand is emitted as its own stacked block before its own children,
+    so the output reads parent-then-descendants. Hidden commands are skipped at
+    every level, matching ``--help``. A negative ``depth`` recurses without limit
+    (it never decrements to 0, so it stops only at leaf commands).
+    """
+    if depth == 0 or not _is_click_group(command):
+        return []
+    blocks: List[str] = []
+    for sub_name, subcommand in command.commands.items():
+        if getattr(subcommand, "hidden", False):
+            continue
+        sub_display = f"{display} {sub_name}".strip()
+        blocks.append(
+            _one_block(subcommand, sub_display, options, style=STACKED_BLOCK_STYLE)
+        )
+        blocks.extend(_subcommand_blocks(subcommand, sub_display, options, depth - 1))
+    return blocks
 
 
 def render_termynal_html(
     module: str,
     name: str,
     options: Optional[TermynalOptions] = None,
-    *,
-    recurse: bool = True,
 ) -> str:
     """Render ``module``'s app help as one or more termynal HTML blocks.
 
-    The root command is always rendered; when ``recurse`` is true and the app is
-    a group, each non-hidden direct subcommand is rendered as its own block.
+    The root command's ``--help`` is always rendered as a single block. Each
+    extra level of ``options.subcommands`` adds a stacked block per non-hidden
+    subcommand at that depth; at the default of 0 only the root block is emitted
+    (matching a bare ``<cmd> --help``).
     """
     options = _normalized(options or TermynalOptions())
 
@@ -218,18 +265,6 @@ def render_termynal_html(
     display = name or command.name or ""
 
     blocks: List[str] = [_one_block(command, display, options)]
-
-    if recurse and _is_click_group(command):
-        for sub_name, subcommand in command.commands.items():
-            if getattr(subcommand, "hidden", False):
-                continue
-            blocks.append(
-                _one_block(
-                    subcommand,
-                    f"{display} {sub_name}".strip(),
-                    options,
-                    style=STACKED_BLOCK_STYLE,
-                )
-            )
+    blocks.extend(_subcommand_blocks(command, display, options, options.subcommands))
 
     return "\n".join(blocks)

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -1,0 +1,161 @@
+"""Render a Typer/Click app's ``--help`` as termynal HTML blocks.
+
+See the "Termynal Output Mode" section of the README for how this works and the
+coupling to termynal's markup contract.
+"""
+
+import importlib
+import io
+from typing import List
+
+import click
+
+from .pretty import _is_click_group, _resolve_click_command
+
+
+def _html_escape(text: str) -> str:
+    text = text.replace("&", "&amp;")
+    text = text.replace("<", "&lt;")
+    text = text.replace(">", "&gt;")
+    return text.replace('"', "&quot;")
+
+
+def _ansi_to_html(text: str, scheme: str, dark_bg: bool) -> str:
+    """Convert ANSI output to balanced inline HTML spans joined with ``<br>``."""
+    converter = None
+    lines: List[str] = []
+    for line in text.split("\n"):
+        if "\x1b" not in line:
+            lines.append(_html_escape(line))
+            continue
+        if converter is None:
+            try:
+                from ansi2html import Ansi2HTMLConverter
+            except ModuleNotFoundError as exc:
+                raise ModuleNotFoundError(
+                    "Termynal output mode requires the 'termynal' extra. "
+                    "Install it with: pip install 'mkdocs-typer2[termynal]'"
+                ) from exc
+
+            converter = Ansi2HTMLConverter(inline=True, scheme=scheme, dark_bg=dark_bg)
+        lines.append(converter.convert(line, full=False))
+    return "<br>".join(lines)
+
+
+def _termynal_block_html(
+    title: str, prompt: str, input_text: str, output_html: str, buttons: str = "macos"
+) -> str:
+    """Wrap a prompt line and output in termynal's ``data-ty`` markup."""
+    return (
+        f'<div class="termy" data-termynal data-ty-{buttons} '
+        f'data-ty-title="{_html_escape(title)}">'
+        f'<span data-ty="input" data-ty-prompt="{_html_escape(prompt)}">'
+        f"{_html_escape(input_text)}</span>"
+        f"<span data-ty>{output_html}</span>"
+        f"</div>"
+    )
+
+
+def _colored_help(command: click.core.Command, info_name: str, width: int = 80) -> str:
+    """Return the command's ``--help`` text, colored when the app uses rich."""
+    formatter = None
+    buf = io.StringIO()
+
+    import typer.rich_utils as ru
+    from rich.console import Console
+
+    original = ru._get_rich_console
+    ru._get_rich_console = lambda stderr=False: Console(  # noqa: ARG005
+        force_terminal=True,
+        color_system="standard",
+        width=width,
+        file=buf,
+        highlight=False,
+    )
+    try:
+        ctx = click.Context(command, info_name=info_name)
+        formatter = ctx.make_formatter()
+        command.format_help(ctx, formatter)
+    finally:
+        ru._get_rich_console = original
+
+    rich_text = buf.getvalue()
+    if rich_text.strip():
+        return rich_text
+    return formatter.getvalue() if formatter is not None else ""
+
+
+def _resolve_app(module: str, name: str) -> click.core.Command:
+    module_ref = importlib.import_module(module)
+    app = getattr(module_ref, name, None) if name else None
+    if app is None:
+        app = getattr(module_ref, "app", None)
+    if app is None:
+        raise ValueError(f"Unable to resolve Typer/Click app from module '{module}'.")
+    return _resolve_click_command(app)
+
+
+def _one_block(
+    command: click.core.Command,
+    info_name: str,
+    *,
+    width: int,
+    ansi_scheme: str,
+    ansi_dark_bg: bool,
+    prompt: str,
+) -> str:
+    help_text = _colored_help(command, info_name, width=width).rstrip("\n")
+    output_html = _ansi_to_html(help_text, ansi_scheme, ansi_dark_bg)
+    return _termynal_block_html(
+        title=info_name,
+        prompt=prompt,
+        input_text=f"{info_name} --help",
+        output_html=output_html,
+    )
+
+
+def render_termynal_html(
+    module: str,
+    name: str,
+    *,
+    width: int = 80,
+    ansi_scheme: str = "xterm",
+    ansi_dark_bg: bool = True,
+    prompt: str = "$",
+    recurse: bool = True,
+) -> str:
+    """Render ``module``'s app help as one or more termynal HTML blocks.
+
+    The root command is always rendered; when ``recurse`` is true and the app is
+    a group, each non-hidden direct subcommand is rendered as its own block.
+    """
+    command = _resolve_app(module, name)
+    display = name or command.name or ""
+
+    blocks: List[str] = [
+        _one_block(
+            command,
+            display,
+            width=width,
+            ansi_scheme=ansi_scheme,
+            ansi_dark_bg=ansi_dark_bg,
+            prompt=prompt,
+        )
+    ]
+
+    if recurse and _is_click_group(command):
+        for sub_name, subcommand in command.commands.items():
+            if getattr(subcommand, "hidden", False):
+                continue
+            blocks.append(
+                _one_block(
+                    subcommand,
+                    f"{display} {sub_name}".strip(),
+                    width=width,
+                    ansi_scheme=ansi_scheme,
+                    ansi_dark_bg=ansi_dark_bg,
+                    prompt=prompt,
+                )
+            )
+
+    return "\n".join(blocks)

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -5,13 +5,20 @@ coupling to termynal's markup contract.
 """
 
 import io
-from typing import List
+from dataclasses import dataclass, replace
+from typing import Dict, List, Literal, Optional, Tuple, get_args
 
 import click
 
 from .pretty import _is_click_group, resolve_click_command
 
-ANSI_SCHEMES = (
+# --- termynal contract --------------------------------------------------------
+# All option domains and the ``data-ty-*`` attribute names we emit live here as
+# the single source of truth. ``tests/test_termynal_contract.py`` guards the
+# attribute names against termynal's own CSS/JS, so they fail loudly if termynal
+# ever renames them.
+
+AnsiScheme = Literal[
     "ansi2html",
     "dracula",
     "mint-terminal",
@@ -20,8 +27,47 @@ ANSI_SCHEMES = (
     "osx-solid-colors",
     "solarized",
     "xterm",
-)
-DEFAULT_ANSI_SCHEME = "xterm"
+]
+ANSI_SCHEMES: Tuple[str, ...] = get_args(AnsiScheme)
+DEFAULT_ANSI_SCHEME: AnsiScheme = "xterm"
+
+ButtonStyle = Literal["macos", "windows"]
+BUTTONS: Tuple[str, ...] = get_args(ButtonStyle)
+DEFAULT_BUTTONS: ButtonStyle = "macos"
+
+DEFAULT_PROMPT = "$"
+
+# termynal.js reads these per-element timing attributes at runtime (its
+# constructor does ``getAttribute('data-ty-typeDelay')`` etc.). We emit them
+# only when explicitly set, otherwise termynal's own defaults apply.
+TIMING_ATTRS: Dict[str, str] = {
+    "type_delay": "data-ty-typeDelay",
+    "line_delay": "data-ty-lineDelay",
+    "start_delay": "data-ty-startDelay",
+}
+
+# termynal styles ``[data-termynal]`` with padding but no margin, so stacked
+# blocks would touch. This spaces them apart without imposing a margin on the
+# boundary between the first/last block and surrounding page content.
+STACKED_BLOCK_STYLE = "margin-top: 1.5rem;"
+
+
+@dataclass
+class TermynalOptions:
+    """Resolved termynal render options (plugin config + per-directive overrides).
+
+    ``scheme`` and ``buttons`` are validated at render time; an out-of-domain
+    value (directive input is free text) falls back to its default.
+    """
+
+    width: int = 80
+    scheme: AnsiScheme = DEFAULT_ANSI_SCHEME
+    dark_bg: bool = True
+    buttons: ButtonStyle = DEFAULT_BUTTONS
+    prompt: str = DEFAULT_PROMPT
+    type_delay: Optional[int] = None
+    line_delay: Optional[int] = None
+    start_delay: Optional[int] = None
 
 
 def _html_escape(text: str) -> str:
@@ -58,20 +104,35 @@ def _termynal_block_html(
     prompt: str,
     input_text: str,
     output_html: str,
-    buttons: str = "macos",
+    *,
+    buttons: ButtonStyle = DEFAULT_BUTTONS,
+    type_delay: Optional[int] = None,
+    line_delay: Optional[int] = None,
+    start_delay: Optional[int] = None,
     style: str = "",
 ) -> str:
     """Wrap a prompt line and output in termynal's ``data-ty`` markup.
 
-    ``style`` is an optional inline style applied to the block; the renderer
-    uses it only to space *stacked* blocks apart, since termynal styles
-    ``[data-termynal]`` with padding but no margin. A lone block gets none, so
-    spacing against surrounding page content stays the theme's concern.
+    ``style`` is an optional inline style; the renderer uses it only to space
+    *stacked* blocks apart (a lone block gets none, so spacing against
+    surrounding page content stays the theme's concern). The timing arguments
+    emit the matching ``data-ty-*`` attributes only when set, deferring to
+    termynal's own defaults otherwise.
     """
-    style_attr = f'style="{_html_escape(style)}" ' if style else ""
+    extra = ""
+    if style:
+        extra += f'style="{_html_escape(style)}" '
+    delays = {
+        "type_delay": type_delay,
+        "line_delay": line_delay,
+        "start_delay": start_delay,
+    }
+    for field, value in delays.items():
+        if value is not None:
+            extra += f'{TIMING_ATTRS[field]}="{int(value)}" '
     return (
         f'<div class="termy" data-termynal data-ty-{buttons} '
-        f"{style_attr}"
+        f"{extra}"
         f'data-ty-title="{_html_escape(title)}">'
         f'<span data-ty="input" data-ty-prompt="{_html_escape(prompt)}">'
         f"{_html_escape(input_text)}</span>"
@@ -112,32 +173,38 @@ def _colored_help(command: click.core.Command, info_name: str, width: int = 80) 
 def _one_block(
     command: click.core.Command,
     info_name: str,
-    *,
-    width: int,
-    ansi_scheme: str,
-    ansi_dark_bg: bool,
-    prompt: str,
+    options: TermynalOptions,
     style: str = "",
 ) -> str:
-    help_text = _colored_help(command, info_name, width=width).rstrip("\n")
-    output_html = _ansi_to_html(help_text, ansi_scheme, ansi_dark_bg)
+    help_text = _colored_help(command, info_name, width=options.width).rstrip("\n")
+    output_html = _ansi_to_html(help_text, options.scheme, options.dark_bg)
     return _termynal_block_html(
         title=info_name,
-        prompt=prompt,
+        prompt=options.prompt,
         input_text=f"{info_name} --help",
         output_html=output_html,
+        buttons=options.buttons,
+        type_delay=options.type_delay,
+        line_delay=options.line_delay,
+        start_delay=options.start_delay,
         style=style,
     )
+
+
+def _normalized(options: TermynalOptions) -> TermynalOptions:
+    """Coerce an out-of-domain ``scheme``/``buttons`` back to its default."""
+    scheme = options.scheme if options.scheme in ANSI_SCHEMES else DEFAULT_ANSI_SCHEME
+    buttons = options.buttons if options.buttons in BUTTONS else DEFAULT_BUTTONS
+    if scheme == options.scheme and buttons == options.buttons:
+        return options
+    return replace(options, scheme=scheme, buttons=buttons)
 
 
 def render_termynal_html(
     module: str,
     name: str,
+    options: Optional[TermynalOptions] = None,
     *,
-    width: int = 80,
-    ansi_scheme: str = DEFAULT_ANSI_SCHEME,
-    ansi_dark_bg: bool = True,
-    prompt: str = "$",
     recurse: bool = True,
 ) -> str:
     """Render ``module``'s app help as one or more termynal HTML blocks.
@@ -145,22 +212,12 @@ def render_termynal_html(
     The root command is always rendered; when ``recurse`` is true and the app is
     a group, each non-hidden direct subcommand is rendered as its own block.
     """
-    if ansi_scheme not in ANSI_SCHEMES:
-        ansi_scheme = DEFAULT_ANSI_SCHEME
+    options = _normalized(options or TermynalOptions())
 
     command = resolve_click_command(module, name)
     display = name or command.name or ""
 
-    blocks: List[str] = [
-        _one_block(
-            command,
-            display,
-            width=width,
-            ansi_scheme=ansi_scheme,
-            ansi_dark_bg=ansi_dark_bg,
-            prompt=prompt,
-        )
-    ]
+    blocks: List[str] = [_one_block(command, display, options)]
 
     if recurse and _is_click_group(command):
         for sub_name, subcommand in command.commands.items():
@@ -170,13 +227,8 @@ def render_termynal_html(
                 _one_block(
                     subcommand,
                     f"{display} {sub_name}".strip(),
-                    width=width,
-                    ansi_scheme=ansi_scheme,
-                    ansi_dark_bg=ansi_dark_bg,
-                    prompt=prompt,
-                    # Space stacked blocks apart without imposing a margin on
-                    # the boundary between the first/last block and page content.
-                    style="margin-top: 1.5rem;",
+                    options,
+                    style=STACKED_BLOCK_STYLE,
                 )
             )
 

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -12,6 +12,18 @@ import click
 
 from .pretty import _is_click_group, _resolve_click_command
 
+ANSI_SCHEMES = (
+    "ansi2html",
+    "dracula",
+    "mint-terminal",
+    "osx",
+    "osx-basic",
+    "osx-solid-colors",
+    "solarized",
+    "xterm",
+)
+DEFAULT_ANSI_SCHEME = "xterm"
+
 
 def _html_escape(text: str) -> str:
     text = text.replace("&", "&amp;")
@@ -119,7 +131,7 @@ def render_termynal_html(
     name: str,
     *,
     width: int = 80,
-    ansi_scheme: str = "xterm",
+    ansi_scheme: str = DEFAULT_ANSI_SCHEME,
     ansi_dark_bg: bool = True,
     prompt: str = "$",
     recurse: bool = True,
@@ -129,6 +141,9 @@ def render_termynal_html(
     The root command is always rendered; when ``recurse`` is true and the app is
     a group, each non-hidden direct subcommand is rendered as its own block.
     """
+    if ansi_scheme not in ANSI_SCHEMES:
+        ansi_scheme = DEFAULT_ANSI_SCHEME
+
     command = _resolve_app(module, name)
     display = name or command.name or ""
 

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -55,11 +55,24 @@ def _ansi_to_html(text: str, scheme: str, dark_bg: bool) -> str:
 
 
 def _termynal_block_html(
-    title: str, prompt: str, input_text: str, output_html: str, buttons: str = "macos"
+    title: str,
+    prompt: str,
+    input_text: str,
+    output_html: str,
+    buttons: str = "macos",
+    style: str = "",
 ) -> str:
-    """Wrap a prompt line and output in termynal's ``data-ty`` markup."""
+    """Wrap a prompt line and output in termynal's ``data-ty`` markup.
+
+    ``style`` is an optional inline style applied to the block; the renderer
+    uses it only to space *stacked* blocks apart, since termynal styles
+    ``[data-termynal]`` with padding but no margin. A lone block gets none, so
+    spacing against surrounding page content stays the theme's concern.
+    """
+    style_attr = f'style="{_html_escape(style)}" ' if style else ""
     return (
         f'<div class="termy" data-termynal data-ty-{buttons} '
+        f"{style_attr}"
         f'data-ty-title="{_html_escape(title)}">'
         f'<span data-ty="input" data-ty-prompt="{_html_escape(prompt)}">'
         f"{_html_escape(input_text)}</span>"
@@ -115,6 +128,7 @@ def _one_block(
     ansi_scheme: str,
     ansi_dark_bg: bool,
     prompt: str,
+    style: str = "",
 ) -> str:
     help_text = _colored_help(command, info_name, width=width).rstrip("\n")
     output_html = _ansi_to_html(help_text, ansi_scheme, ansi_dark_bg)
@@ -123,6 +137,7 @@ def _one_block(
         prompt=prompt,
         input_text=f"{info_name} --help",
         output_html=output_html,
+        style=style,
     )
 
 
@@ -170,6 +185,9 @@ def render_termynal_html(
                     ansi_scheme=ansi_scheme,
                     ansi_dark_bg=ansi_dark_bg,
                     prompt=prompt,
+                    # Space stacked blocks apart without imposing a margin on
+                    # the boundary between the first/last block and page content.
+                    style="margin-top: 1.5rem;",
                 )
             )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,7 @@ from mkdocs_typer2.markdown import TyperExtension
 
 def test_plugin_on_config():
     plugin = MkdocsTyper()
+    plugin.load_config({})
     # Initialize with empty markdown_extensions list
     config = {"markdown_extensions": []}
 
@@ -17,6 +18,7 @@ def test_plugin_on_config():
 
 def test_plugin_on_config_with_existing_extensions():
     plugin = MkdocsTyper()
+    plugin.load_config({})
     # Initialize with some existing extensions
     existing_extension = "existing_extension"
     config = {"markdown_extensions": [existing_extension]}
@@ -37,6 +39,7 @@ def test_plugin_termynal_config_threads_through():
             "termynal_width": 100,
             "termynal_buttons": "windows",
             "termynal_type_delay": 5,
+            "termynal_subcommands": -1,
         }
     )
     assert not errors and not warnings
@@ -50,6 +53,7 @@ def test_plugin_termynal_config_threads_through():
     assert options.width == 100
     assert options.buttons == "windows"
     assert options.type_delay == 5
+    assert options.subcommands == -1
     # Unspecified options fall back to their defaults.
     assert options.scheme == "xterm"
     assert options.line_delay is None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,31 @@
+import pytest
+
 from mkdocs_typer2.plugin import MkdocsTyper
-from mkdocs_typer2.markdown import TyperExtension
+from mkdocs_typer2.markdown import TyperExtension, _as_bool, _as_int
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("true", True), ("YES", True), ("0", False), ("no", False)],
+)
+def test_as_bool_recognized_values(value, expected):
+    assert _as_bool(value, default=not expected) is expected
+
+
+@pytest.mark.parametrize("value", [None, "maybe", ""])
+def test_as_bool_falls_back_to_default(value):
+    # Unrecognized (or missing) input keeps the supplied default.
+    assert _as_bool(value, default=True) is True
+    assert _as_bool(value, default=False) is False
+
+
+def test_as_int_parses_and_falls_back():
+    assert _as_int("42", default=1) == 42
+    assert _as_int("-1", default=0) == -1
+    # Non-integer and missing input keep the default.
+    assert _as_int("abc", default=7) == 7
+    assert _as_int(None, default=7) == 7
+    assert _as_int("abc", default=None) is None
 
 
 def test_plugin_on_config():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -29,6 +29,32 @@ def test_plugin_on_config_with_existing_extensions():
     assert isinstance(result["markdown_extensions"][1], TyperExtension)
 
 
+def test_plugin_termynal_config_threads_through():
+    plugin = MkdocsTyper()
+    errors, warnings = plugin.load_config(
+        {
+            "termynal": True,
+            "termynal_width": 100,
+            "termynal_buttons": "windows",
+            "termynal_type_delay": 5,
+        }
+    )
+    assert not errors and not warnings
+
+    config = {"markdown_extensions": []}
+    plugin.on_config(config)
+    extension = config["markdown_extensions"][0]
+
+    assert extension.termynal is True
+    options = extension.termynal_options
+    assert options.width == 100
+    assert options.buttons == "windows"
+    assert options.type_delay == 5
+    # Unspecified options fall back to their defaults.
+    assert options.scheme == "xterm"
+    assert options.line_delay is None
+
+
 def test_plugin_on_pre_build():
     plugin = MkdocsTyper()
     config = {}

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,31 +1,5 @@
-import pytest
-
 from mkdocs_typer2.plugin import MkdocsTyper
-from mkdocs_typer2.markdown import TyperExtension, _as_bool, _as_int
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [("true", True), ("YES", True), ("0", False), ("no", False)],
-)
-def test_as_bool_recognized_values(value, expected):
-    assert _as_bool(value, default=not expected) is expected
-
-
-@pytest.mark.parametrize("value", [None, "maybe", ""])
-def test_as_bool_falls_back_to_default(value):
-    # Unrecognized (or missing) input keeps the supplied default.
-    assert _as_bool(value, default=True) is True
-    assert _as_bool(value, default=False) is False
-
-
-def test_as_int_parses_and_falls_back():
-    assert _as_int("42", default=1) == 42
-    assert _as_int("-1", default=0) == -1
-    # Non-integer and missing input keep the default.
-    assert _as_int("abc", default=7) == 7
-    assert _as_int(None, default=7) == 7
-    assert _as_int("abc", default=None) is None
+from mkdocs_typer2.markdown import TyperExtension
 
 
 def test_plugin_on_config():

--- a/tests/test_termynal_contract.py
+++ b/tests/test_termynal_contract.py
@@ -4,7 +4,11 @@ own output, so a future termynal markup change fails loudly here.
 
 import pytest
 
-from mkdocs_typer2.termynal_render import _termynal_block_html
+from mkdocs_typer2.termynal_render import (
+    BUTTONS,
+    TIMING_ATTRS,
+    _termynal_block_html,
+)
 
 pytest.importorskip("termynal.markdown")
 
@@ -35,4 +39,30 @@ def test_emitted_markup_matches_termynal_contract(token: str) -> None:
     assert token in reference, (
         f"termynal no longer emits {token!r} — its markup contract drifted; "
         "update _termynal_block_html in termynal_render.py to match."
+    )
+
+
+@pytest.mark.parametrize("buttons", BUTTONS)
+def test_button_attrs_match_termynal_css(buttons: str) -> None:
+    """The window-chrome attributes we emit must be the ones termynal styles."""
+    from termynal.markdown import get_default_css
+
+    attr = f"data-ty-{buttons}"
+    assert attr in get_default_css(), (
+        f"termynal CSS no longer styles {attr!r}; the button contract drifted — "
+        "update BUTTONS in termynal_render.py to match."
+    )
+
+
+@pytest.mark.parametrize("attr", sorted(TIMING_ATTRS.values()))
+def test_timing_attrs_match_termynal_js(attr: str) -> None:
+    """The timing attributes we emit must be the ones termynal.js reads."""
+    from termynal.markdown import get_default_js
+
+    # termynal.js reads these via getAttribute(`data-ty-typeDelay`) etc., built
+    # from a `data-ty` prefix + the suffix; the suffix is the literal in source.
+    suffix = attr[len("data-ty") :]
+    assert suffix in get_default_js(), (
+        f"termynal.js no longer reads {attr!r}; the timing contract drifted — "
+        "update TIMING_ATTRS in termynal_render.py to match."
     )

--- a/tests/test_termynal_contract.py
+++ b/tests/test_termynal_contract.py
@@ -20,10 +20,10 @@ CONTRACT_TOKENS = [
 
 
 def _termynal_reference_markup() -> str:
-    from termynal.markdown import Termynal, parse_config_from_dict
+    from termynal.markdown import Termynal, escape, parse_config_from_dict
 
     termynal = Termynal(parse_config_from_dict({"title": "demo"}))
-    return termynal.convert(termynal.escape("$ demo --help\nhello"))
+    return termynal.convert(escape("$ demo --help\nhello"))
 
 
 @pytest.mark.parametrize("token", CONTRACT_TOKENS)

--- a/tests/test_termynal_contract.py
+++ b/tests/test_termynal_contract.py
@@ -7,8 +7,26 @@ import pytest
 from mkdocs_typer2.termynal_render import (
     BUTTONS,
     TIMING_ATTRS,
+    TYPER_RICH_CONSOLE_HOOK,
     _termynal_block_html,
 )
+
+
+def test_typer_rich_console_hook_present() -> None:
+    """``_colored_help`` swaps typer's private rich-console factory to capture
+    colored ``--help`` (typer exposes no public hook for this). If typer renames
+    or removes it, color silently degrades to monochrome — fail loudly here so
+    the drift is caught in CI rather than shipped. Needs only typer, so it runs
+    even without the optional termynal extra installed.
+    """
+    import typer.rich_utils as ru
+
+    assert callable(getattr(ru, TYPER_RICH_CONSOLE_HOOK, None)), (
+        f"typer.rich_utils.{TYPER_RICH_CONSOLE_HOOK} is gone — the termynal "
+        "color-capture contract drifted. Update TYPER_RICH_CONSOLE_HOOK and "
+        "_colored_help in termynal_render.py to typer's new console factory."
+    )
+
 
 pytest.importorskip("termynal.markdown")
 

--- a/tests/test_termynal_contract.py
+++ b/tests/test_termynal_contract.py
@@ -1,0 +1,38 @@
+"""Drift guard: every ``data-ty`` token we emit must also appear in termynal's
+own output, so a future termynal markup change fails loudly here.
+"""
+
+import pytest
+
+from mkdocs_typer2.termynal_render import _termynal_block_html
+
+pytest.importorskip("termynal.markdown")
+
+CONTRACT_TOKENS = [
+    'class="termy"',
+    "data-termynal",
+    "data-ty-macos",
+    "data-ty-title=",
+    'data-ty="input"',
+    'data-ty-prompt="$"',
+    "<span data-ty>",
+]
+
+
+def _termynal_reference_markup() -> str:
+    from termynal.markdown import Termynal, parse_config_from_dict
+
+    termynal = Termynal(parse_config_from_dict({"title": "demo"}))
+    return termynal.convert(termynal.escape("$ demo --help\nhello"))
+
+
+@pytest.mark.parametrize("token", CONTRACT_TOKENS)
+def test_emitted_markup_matches_termynal_contract(token: str) -> None:
+    ours = _termynal_block_html("demo", "$", "demo --help", "hello")
+    reference = _termynal_reference_markup()
+
+    assert token in ours, f"our renderer stopped emitting {token!r}"
+    assert token in reference, (
+        f"termynal no longer emits {token!r} — its markup contract drifted; "
+        "update _termynal_block_html in termynal_render.py to match."
+    )

--- a/tests/test_termynal_directive.py
+++ b/tests/test_termynal_directive.py
@@ -1,0 +1,33 @@
+"""Tests for the termynal directive-parsing helpers.
+
+These coerce free-text directive values (``:width:``, ``:dark_bg:`` …) for the
+termynal output mode and need no optional extra, so they run unconditionally.
+"""
+
+import pytest
+
+from mkdocs_typer2.markdown import _as_bool, _as_int
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [("true", True), ("YES", True), ("0", False), ("no", False)],
+)
+def test_as_bool_recognized_values(value, expected):
+    assert _as_bool(value, default=not expected) is expected
+
+
+@pytest.mark.parametrize("value", [None, "maybe", ""])
+def test_as_bool_falls_back_to_default(value):
+    # Unrecognized (or missing) input keeps the supplied default.
+    assert _as_bool(value, default=True) is True
+    assert _as_bool(value, default=False) is False
+
+
+def test_as_int_parses_and_falls_back():
+    assert _as_int("42", default=1) == 42
+    assert _as_int("-1", default=0) == -1
+    # Non-integer and missing input keep the default.
+    assert _as_int("abc", default=7) == 7
+    assert _as_int(None, default=7) == 7
+    assert _as_int("abc", default=None) is None

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -22,7 +22,11 @@ from mkdocs_typer2.termynal_render import (  # noqa: E402
 
 
 def test_render_termynal_html_typer_colored_and_balanced():
-    html = render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2")
+    # Depth 1 so a subcommand block (which carries colored type annotations) is
+    # included; the root --help of this CLI is styled bold-only.
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(subcommands=1)
+    )
 
     # It is a termynal block.
     assert "data-termynal" in html
@@ -32,13 +36,35 @@ def test_render_termynal_html_typer_colored_and_balanced():
     assert html.count("<span") == html.count("</span>")
 
 
-def test_render_termynal_html_recurses_into_subcommands():
+def test_render_termynal_html_root_only_by_default():
     html = render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2")
+
+    # Default depth is 0: only the root command's --help, no subcommand blocks.
+    assert html.count("data-termynal") == 1
+    assert "mkdocs-typer2 docs --help" not in html
+
+
+def test_render_termynal_html_recurses_into_subcommands():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(subcommands=1)
+    )
 
     # The root block plus one block per direct subcommand.
     assert html.count("data-termynal") >= 2
     # A known subcommand prompt line is present (recursion happened).
     assert "mkdocs-typer2 docs --help" in html
+
+
+def test_render_termynal_html_unlimited_depth_with_negative():
+    full = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(subcommands=-1)
+    )
+    one_level = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(subcommands=1)
+    )
+
+    # -1 means "all levels", so it renders at least as many blocks as one level.
+    assert full.count("data-termynal") >= one_level.count("data-termynal") >= 2
 
 
 def test_render_termynal_html_plain_click_monochrome(monkeypatch):
@@ -52,7 +78,7 @@ def test_render_termynal_html_plain_click_monochrome(monkeypatch):
     module.cli = cli
     monkeypatch.setitem(sys.modules, "_plain_click_app", module)
 
-    html = render_termynal_html("_plain_click_app", "cli", recurse=False)
+    html = render_termynal_html("_plain_click_app", "cli")
 
     assert "data-termynal" in html
     # Plain Click help is not colored.
@@ -72,20 +98,28 @@ def test_invalid_scheme_falls_back_to_xterm():
         "mkdocs_typer2.cli.cli",
         "mkdocs-typer2",
         TermynalOptions(scheme="not-a-scheme"),
-        recurse=False,
+    )
+    assert "data-termynal" in html
+
+
+def test_non_positive_width_falls_back_to_safe_value():
+    """A zero/negative width must not reach rich.Console (it would raise)."""
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(width=0),
     )
     assert "data-termynal" in html
 
 
 def test_buttons_option_selects_window_chrome():
     macos = render_termynal_html(
-        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(), recurse=False
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions()
     )
     windows = render_termynal_html(
         "mkdocs_typer2.cli.cli",
         "mkdocs-typer2",
         TermynalOptions(buttons="windows"),
-        recurse=False,
     )
     assert "data-ty-macos" in macos and "data-ty-windows" not in macos
     assert "data-ty-windows" in windows and "data-ty-macos" not in windows
@@ -96,7 +130,6 @@ def test_invalid_buttons_falls_back_to_macos():
         "mkdocs_typer2.cli.cli",
         "mkdocs-typer2",
         TermynalOptions(buttons="bogus"),
-        recurse=False,
     )
     assert "data-ty-macos" in html
     assert "data-ty-bogus" not in html
@@ -107,7 +140,6 @@ def test_prompt_option_changes_prompt_attribute():
         "mkdocs_typer2.cli.cli",
         "mkdocs-typer2",
         TermynalOptions(prompt=">>>"),
-        recurse=False,
     )
     assert 'data-ty-prompt="&gt;&gt;&gt;"' in html
     assert 'data-ty-prompt="$"' not in html
@@ -115,7 +147,7 @@ def test_prompt_option_changes_prompt_attribute():
 
 def test_timing_attributes_emitted_only_when_set():
     default = render_termynal_html(
-        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(), recurse=False
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions()
     )
     # No timing attributes unless explicitly configured (termynal defaults apply).
     assert "data-ty-typeDelay" not in default
@@ -124,7 +156,6 @@ def test_timing_attributes_emitted_only_when_set():
         "mkdocs_typer2.cli.cli",
         "mkdocs-typer2",
         TermynalOptions(type_delay=10, line_delay=20, start_delay=30),
-        recurse=False,
     )
     assert 'data-ty-typeDelay="10"' in tuned
     assert 'data-ty-lineDelay="20"' in tuned
@@ -145,6 +176,24 @@ def test_buttons_and_delay_thread_through_directive():
     )
     assert "data-ty-windows" in html
     assert 'data-ty-typeDelay="5"' in html
+
+
+def test_subcommands_depth_threads_through_directive():
+    def render(extra=""):
+        directive = (
+            "::: mkdocs-typer2\n"
+            "    :module: mkdocs_typer2.cli.cli\n"
+            "    :name: mkdocs-typer2\n"
+            "    :termynal: true\n"
+            f"{extra}"
+        )
+        return markdown.markdown(
+            directive, extensions=["tables", TyperExtension(engine="native")]
+        )
+
+    # Default (no :subcommands:) is root-only; :subcommands: 1 adds blocks.
+    assert render().count("data-termynal") == 1
+    assert render("    :subcommands: 1\n").count("data-termynal") >= 2
 
 
 def test_scheme_option_through_directive():
@@ -170,6 +219,7 @@ def test_termynal_end_to_end_through_markdown_pipeline():
         "    :module: mkdocs_typer2.cli.cli\n"
         "    :name: mkdocs-typer2\n"
         "    :termynal: true\n"
+        "    :subcommands: 1\n"
     )
 
     html = markdown.markdown(

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -192,6 +192,41 @@ def test_render_termynal_html_plain_click_monochrome(monkeypatch):
     assert 'style="color:' not in html
 
 
+def test_missing_rich_console_hook_renders_without_crash_or_leak(monkeypatch, capsys):
+    """The safe-fallback branch: when typer's private console hook is absent,
+    rendering must still emit a block via plain ``format_help`` without crashing
+    or leaking help to stdout.
+
+    A real typer *rename* also rewrites typer's own ``rich_format_help`` to the
+    new name, so it can't be simulated by deleting the symbol (that just breaks
+    typer internally). A plain Click command never touches the hook, so it
+    exercises the ``else`` branch deterministically: it goes through the
+    stdout-redirected path and falls back to the Click formatter.
+    """
+    import typer.rich_utils as ru
+
+    from mkdocs_typer2.termynal_render import TYPER_RICH_CONSOLE_HOOK
+
+    monkeypatch.delattr(ru, TYPER_RICH_CONSOLE_HOOK, raising=False)
+
+    module = types.ModuleType("_plain_click_fallback_app")
+
+    @click.command()
+    def cli():
+        """A plain click command."""
+
+    module.cli = cli
+    monkeypatch.setitem(sys.modules, "_plain_click_fallback_app", module)
+
+    html = render_termynal_html("_plain_click_fallback_app", "cli")
+
+    # Still a real block, monochrome, and nothing leaked to the console.
+    assert "data-termynal" in html
+    assert "cli --help" in html
+    assert 'style="color:' not in html
+    assert capsys.readouterr().out == ""
+
+
 def test_scheme_changes_colors():
     from mkdocs_typer2.termynal_render import _ansi_to_html
 

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -287,6 +287,21 @@ def test_prompt_option_changes_prompt_attribute():
     assert 'data-ty-prompt="$"' not in html
 
 
+def test_multi_word_prompt_threads_through_directive():
+    directive = (
+        "::: mkdocs-typer2\n"
+        "    :module: mkdocs_typer2.cli.cli\n"
+        "    :name: mkdocs-typer2\n"
+        "    :termynal: true\n"
+        "    :prompt: my prompt\n"
+    )
+    html = markdown.markdown(
+        directive, extensions=["tables", TyperExtension(engine="native")]
+    )
+    # The whole prompt is kept, not truncated at the first token.
+    assert 'data-ty-prompt="my prompt"' in html
+
+
 def test_timing_attributes_emitted_only_when_set():
     default = render_termynal_html(
         "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions()

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -154,9 +154,7 @@ def test_subcommands_recursion_reaches_sub_subcommands(monkeypatch):
 
 def test_command_unknown_path_raises():
     with pytest.raises(ValueError, match="no subcommand"):
-        render_termynal_html(
-            "mkdocs_typer2.cli.cli", "mkdocs-typer2", command="nope"
-        )
+        render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2", command="nope")
 
 
 def test_command_threads_through_directive():

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -67,6 +67,62 @@ def test_render_termynal_html_unlimited_depth_with_negative():
     assert full.count("data-termynal") >= one_level.count("data-termynal") >= 2
 
 
+def test_command_selects_a_single_subcommand():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", command="docs"
+    )
+
+    # Exactly the selected command's --help, nothing else.
+    assert html.count("data-termynal") == 1
+    assert "mkdocs-typer2 docs --help" in html
+    assert "mkdocs-typer2 export --help" not in html
+
+
+def test_command_selects_nested_path():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", command="subapp sub-command"
+    )
+
+    assert html.count("data-termynal") == 1
+    assert "mkdocs-typer2 subapp sub-command --help" in html
+
+
+def test_command_subcommands_recurse_relative_to_selection():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(subcommands=1),
+        command="subapp",
+    )
+
+    # The selected group plus its own direct subcommands.
+    assert "mkdocs-typer2 subapp --help" in html
+    assert "mkdocs-typer2 subapp sub-command --help" in html
+    assert "mkdocs-typer2 subapp sub-command-2 --help" in html
+
+
+def test_command_unknown_path_raises():
+    with pytest.raises(ValueError, match="no subcommand"):
+        render_termynal_html(
+            "mkdocs_typer2.cli.cli", "mkdocs-typer2", command="nope"
+        )
+
+
+def test_command_threads_through_directive():
+    directive = (
+        "::: mkdocs-typer2\n"
+        "    :module: mkdocs_typer2.cli.cli\n"
+        "    :name: mkdocs-typer2\n"
+        "    :termynal: true\n"
+        "    :command: subapp sub-command\n"
+    )
+    html = markdown.markdown(
+        directive, extensions=["tables", TyperExtension(engine="native")]
+    )
+    assert "mkdocs-typer2 subapp sub-command --help" in html
+    assert html.count("data-termynal") == 1
+
+
 def test_render_termynal_html_plain_click_monochrome(monkeypatch):
     """A plain ``click.command`` app renders without raising (monochrome)."""
     module = types.ModuleType("_plain_click_app")

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -15,7 +15,10 @@ import pytest
 pytest.importorskip("ansi2html")  # requires the 'termynal' extra
 
 from mkdocs_typer2.markdown import TyperExtension  # noqa: E402
-from mkdocs_typer2.termynal_render import render_termynal_html  # noqa: E402
+from mkdocs_typer2.termynal_render import (  # noqa: E402
+    TermynalOptions,
+    render_termynal_html,
+)
 
 
 def test_render_termynal_html_typer_colored_and_balanced():
@@ -66,9 +69,82 @@ def test_scheme_changes_colors():
 
 def test_invalid_scheme_falls_back_to_xterm():
     html = render_termynal_html(
-        "mkdocs_typer2.cli.cli", "mkdocs-typer2", ansi_scheme="not-a-scheme", recurse=False
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(scheme="not-a-scheme"),
+        recurse=False,
     )
     assert "data-termynal" in html
+
+
+def test_buttons_option_selects_window_chrome():
+    macos = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(), recurse=False
+    )
+    windows = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(buttons="windows"),
+        recurse=False,
+    )
+    assert "data-ty-macos" in macos and "data-ty-windows" not in macos
+    assert "data-ty-windows" in windows and "data-ty-macos" not in windows
+
+
+def test_invalid_buttons_falls_back_to_macos():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(buttons="bogus"),
+        recurse=False,
+    )
+    assert "data-ty-macos" in html
+    assert "data-ty-bogus" not in html
+
+
+def test_prompt_option_changes_prompt_attribute():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(prompt=">>>"),
+        recurse=False,
+    )
+    assert 'data-ty-prompt="&gt;&gt;&gt;"' in html
+    assert 'data-ty-prompt="$"' not in html
+
+
+def test_timing_attributes_emitted_only_when_set():
+    default = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(), recurse=False
+    )
+    # No timing attributes unless explicitly configured (termynal defaults apply).
+    assert "data-ty-typeDelay" not in default
+
+    tuned = render_termynal_html(
+        "mkdocs_typer2.cli.cli",
+        "mkdocs-typer2",
+        TermynalOptions(type_delay=10, line_delay=20, start_delay=30),
+        recurse=False,
+    )
+    assert 'data-ty-typeDelay="10"' in tuned
+    assert 'data-ty-lineDelay="20"' in tuned
+    assert 'data-ty-startDelay="30"' in tuned
+
+
+def test_buttons_and_delay_thread_through_directive():
+    directive = (
+        "::: mkdocs-typer2\n"
+        "    :module: mkdocs_typer2.cli.cli\n"
+        "    :name: mkdocs-typer2\n"
+        "    :termynal: true\n"
+        "    :buttons: windows\n"
+        "    :type_delay: 5\n"
+    )
+    html = markdown.markdown(
+        directive, extensions=["tables", TyperExtension(engine="native")]
+    )
+    assert "data-ty-windows" in html
+    assert 'data-ty-typeDelay="5"' in html
 
 
 def test_scheme_option_through_directive():

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -56,6 +56,38 @@ def test_render_termynal_html_plain_click_monochrome(monkeypatch):
     assert 'style="color:' not in html
 
 
+def test_scheme_changes_colors():
+    from mkdocs_typer2.termynal_render import _ansi_to_html
+
+    red = "\x1b[31mred\x1b[0m"
+    assert "#cd0000" in _ansi_to_html(red, "xterm", True)
+    assert "#c23621" in _ansi_to_html(red, "osx", True)
+
+
+def test_invalid_scheme_falls_back_to_xterm():
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", ansi_scheme="not-a-scheme", recurse=False
+    )
+    assert "data-termynal" in html
+
+
+def test_scheme_option_through_directive():
+    def render(extra=""):
+        directive = (
+            "::: mkdocs-typer2\n"
+            "    :module: mkdocs_typer2.cli.cli\n"
+            "    :name: mkdocs-typer2\n"
+            "    :termynal: true\n"
+            f"{extra}"
+        )
+        return markdown.markdown(
+            directive, extensions=["tables", TyperExtension(engine="native")]
+        )
+
+    # The :scheme: option must thread through and change the rendered palette.
+    assert render() != render("    :scheme: osx\n")
+
+
 def test_termynal_end_to_end_through_markdown_pipeline():
     directive = (
         "::: mkdocs-typer2\n"

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -1,0 +1,75 @@
+"""Tests for the termynal output mode.
+
+Covers the colored Typer render, the monochrome plain-Click fallback,
+subcommand recursion, and the end-to-end ``htmlStash`` injection through the
+full Python-Markdown pipeline.
+"""
+
+import sys
+import types
+
+import click
+import markdown
+import pytest
+
+pytest.importorskip("ansi2html")  # requires the 'termynal' extra
+
+from mkdocs_typer2.markdown import TyperExtension  # noqa: E402
+from mkdocs_typer2.termynal_render import render_termynal_html  # noqa: E402
+
+
+def test_render_termynal_html_typer_colored_and_balanced():
+    html = render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2")
+
+    # It is a termynal block.
+    assert "data-termynal" in html
+    # The fork's CLI is a Typer/rich app, so the help is colored.
+    assert 'style="color:' in html
+    # Colored spans must be balanced.
+    assert html.count("<span") == html.count("</span>")
+
+
+def test_render_termynal_html_recurses_into_subcommands():
+    html = render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2")
+
+    # The root block plus one block per direct subcommand.
+    assert html.count("data-termynal") >= 2
+    # A known subcommand prompt line is present (recursion happened).
+    assert "mkdocs-typer2 docs --help" in html
+
+
+def test_render_termynal_html_plain_click_monochrome(monkeypatch):
+    """A plain ``click.command`` app renders without raising (monochrome)."""
+    module = types.ModuleType("_plain_click_app")
+
+    @click.command()
+    def cli():
+        """A plain click command."""
+
+    module.cli = cli
+    monkeypatch.setitem(sys.modules, "_plain_click_app", module)
+
+    html = render_termynal_html("_plain_click_app", "cli", recurse=False)
+
+    assert "data-termynal" in html
+    # Plain Click help is not colored.
+    assert 'style="color:' not in html
+
+
+def test_termynal_end_to_end_through_markdown_pipeline():
+    directive = (
+        "::: mkdocs-typer2\n"
+        "    :module: mkdocs_typer2.cli.cli\n"
+        "    :name: mkdocs-typer2\n"
+        "    :termynal: true\n"
+    )
+
+    html = markdown.markdown(
+        directive,
+        extensions=["tables", TyperExtension(engine="native")],
+    )
+
+    assert "data-termynal" in html
+    assert 'style="color:' in html
+    # The htmlStash placeholder must be swapped back out (no leak).
+    assert "wzxhzdk" not in html

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -101,6 +101,57 @@ def test_command_subcommands_recurse_relative_to_selection():
     assert "mkdocs-typer2 subapp sub-command-2 --help" in html
 
 
+def _register_nested_typer_app(monkeypatch):
+    """A three-level Typer app (root -> middle -> inner -> leaf-cmd)."""
+    import typer
+
+    module = types.ModuleType("_nested_typer_app")
+    inner = typer.Typer()
+
+    @inner.command()
+    def leaf_cmd():
+        """A leaf command."""
+
+    middle = typer.Typer()
+    middle.add_typer(inner, name="inner")
+
+    @middle.command()
+    def middle_cmd():
+        """A middle command."""
+
+    app = typer.Typer()
+    app.add_typer(middle, name="middle")
+    module.app = app
+    monkeypatch.setitem(sys.modules, "_nested_typer_app", module)
+
+
+def test_command_selects_sub_subcommand(monkeypatch):
+    _register_nested_typer_app(monkeypatch)
+    html = render_termynal_html(
+        "_nested_typer_app", "app", command="middle inner leaf-cmd"
+    )
+
+    assert html.count("data-termynal") == 1
+    assert "app middle inner leaf-cmd --help" in html
+
+
+def test_subcommands_recursion_reaches_sub_subcommands(monkeypatch):
+    _register_nested_typer_app(monkeypatch)
+
+    # Unlimited depth walks the whole tree, including the third level.
+    full = render_termynal_html(
+        "_nested_typer_app", "app", TermynalOptions(subcommands=-1)
+    )
+    assert "app middle inner leaf-cmd --help" in full
+
+    # Depth 1 stops one level down, before the sub-subcommand.
+    one_level = render_termynal_html(
+        "_nested_typer_app", "app", TermynalOptions(subcommands=1)
+    )
+    assert "app middle --help" in one_level
+    assert "app middle inner leaf-cmd --help" not in one_level
+
+
 def test_command_unknown_path_raises():
     with pytest.raises(ValueError, match="no subcommand"):
         render_termynal_html(


### PR DESCRIPTION
Feature request: #36

Hi,
I'm trying to document CLI Typer apps. I really want to document them like they'd be shown in a terminal, so I thought I could combine your repo with https://github.com/termynal/termynal.py to achieve nice, colored documentation. I hope you like it and approve it.

> [!NOTE]
> This description was drafted with AI assistance (Claude); the code is accumulated fork work. Happy to trim or adjust anything.

## What

Adds a `termynal` output mode to the `::: mkdocs-typer2` directive. Instead of Markdown tables, it renders a CLI's `--help` as an animated, **colored terminal** via [termynal](https://github.com/termynal/termynal.py):

```markdown
::: mkdocs-typer2
    :module: my_module.cli
    :name: mycli
    :termynal: true
```

By default only the **root command's `--help`** is rendered. Use `:command:` to render a specific subcommand instead, and `:subcommands:` to stack a depth of subcommand blocks below the selected command. Enable the mode per block (`:termynal: true`) or globally (`termynal: true`).

## Options

Each render option is available per block (`:option:`) and globally (`termynal_`-prefixed, e.g. `termynal_width`); the block-level value wins. `:command:` is block-level only.

| Option | Purpose |
| --- | --- |
| `command` | render a specific subcommand instead of the root, via a space-separated path (`export`, or `subapp sub-command` for nested). `:subcommands:` recursion applies relative to it. Block-level only |
| `subcommands` | recursion depth: `0` selected command only (default), `N` levels deep, `-1` the full tree. Hidden commands skipped at every level |
| `width` | capture width in columns (default 80; floored at 1) |
| `scheme` | ansi2html palette; invalid → `xterm` |
| `dark_bg` | light/dark background variant |
| `buttons` | window chrome `macos` \| `windows`; invalid → `macos` |
| `prompt` | prompt symbol (default `$`) |
| `type_delay` / `line_delay` / `start_delay` | termynal animation timings (ms); unset → termynal's own defaults |

Render options are bundled in a `TermynalOptions` dataclass with `Literal`-typed domains; the option domains and `data-ty-*` attribute names live as module-level constants in `termynal_render.py` as the single source of truth. The per-option **defaults** are sourced from that dataclass by both entry points (the MkDocs `config_scheme` and the Markdown-extension constructor used by Zensical), so the two can't drift apart.

### Per-command blocks

Because `:command:` selects exactly one command, you can document one command per block with your own headings and prose around each — instead of one giant stacked terminal:

```markdown
## Export

::: mkdocs-typer2
    :module: my_module.cli
    :name: mycli
    :termynal: true
    :command: export
```

renders exactly `mycli export --help`.

## How it works

- **In-process introspection** — reuses the existing `native` Click resolution; no subprocess. Each command's `--help` is captured by forcing rich's terminal output, so Typer apps come out colored (plain Click apps render monochrome). Deterministic and cross-platform. Because the renderer only ever produces help text, the prompt line is always `<cmd> --help` so it matches the output exactly. Hidden commands are skipped during recursion, matching `--help`; selecting a hidden command explicitly via `:command:` still renders it.
- **Recursion is opt-in** — the default renders a single block (the selected command's `--help`), matching a bare `<cmd> --help`. `:subcommands: 1` adds one block per non-hidden direct subcommand, higher values go deeper (depth-first, parent-then-descendants), and `-1` walks the whole tree.
- **ANSI → HTML** via `ansi2html`, wrapped in termynal's `data-ty` markup and injected through the markdown `htmlStash`. Because it's a markdown extension, it works under both MkDocs and Zensical.
- **No new hard dependency** — `termynal` + `ansi2html` are an optional extra, `mkdocs-typer2[termynal]`. Using the mode without it raises a clear install hint, and the imports are deferred to when the mode is actually used, so non-termynal users pull nothing extra.
- **Loose coupling** — emits termynal's markup directly rather than importing its renderer (its `convert()` escapes output, which would strip the color). Drift guards in `tests/test_termynal_contract.py` assert the markup tokens against termynal's own output, the button attributes against its CSS, and the timing attributes against its JS — so a future termynal rename fails loudly.
- **Stacked-block spacing** is owned here (termynal styles `[data-termynal]` with padding but no margin); a `margin-top` is applied only *between* stacked blocks, so a lone block imposes no margin on surrounding page content.

## Docs & scope

- A `CLI (Termynal)` page is added to the docs site nav, and the `termynal` MkDocs plugin is enabled so its CSS/JS animate the blocks (builds clean under `mkdocs build --strict`). The README documents the mode and every option.
- Existing `legacy` / `native` / `pretty` behavior is unchanged when `:termynal:` is off.

## Tests

`tests/test_termynal_render.py` (colored Typer, monochrome Click fallback, root-only default, `:command:` selection incl. nested and three-level sub-subcommand paths / unknown-path error / recursion relative to the selection, subcommand recursion at depth 1 and unlimited `-1` verified to reach a third level, each option + invalid-value fallbacks, directive/plugin threading, end-to-end `htmlStash` injection) and `tests/test_termynal_contract.py` (markup / CSS / JS drift guards). Both skip cleanly when the `termynal` extra isn't installed.

A CHANGELOG entry is added under `[Unreleased]`.