### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-16
+
 ### Added
 
 - `termynal` output mode: render a CLI's `--help` as an animated, colored [termynal](https://github.com/termynal/termynal.py) terminal instead of Markdown tables, enabled per block (`:termynal: true`) or globally (`termynal: true`). The app is introspected in-process (no subprocess) and its colored `--help` is converted to termynal markup; by default only the root command is rendered. Requires the optional `[termynal]` extra (`pip install "mkdocs-typer2[termynal]"`); using the mode without it raises a clear install hint ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-typer2"
-version = "0.3.1"
+version = "0.4.0"
 description = "Typer CLI docs for MkDocs (optional) and Zensical via Python-Markdown"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare **0.4.0** for release:

- Bump `version` in `pyproject.toml` to `0.4.0`
- Document termynal output mode and related docs merged since `0.3.1` in `CHANGELOG.md`

## Changes in 0.4.0

- **Added:** `termynal` output mode for animated CLI `--help` rendering ([#35](https://github.com/syn54x/mkdocs-typer2/pull/35))
- **Added:** Termynal directive options (`:command:`, `subcommands`, styling/timing globals)
- **Added:** Termynal docs page and Zensical asset setup notes

## After merge

1. Create GitHub Release `v0.4.0` (publish) to trigger PyPI upload via `publish.yml`
2. Docs site updates automatically on merge to `main`

## Test plan

- [x] Changelog and version bump only
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)