### PR TITLE
fix: keep termynal color when NO_COLOR is set (e.g. ReadTheDocs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Termynal mode now keeps its colors when `NO_COLOR` is set in the build environment (e.g. ReadTheDocs). The capture `Console` passes `no_color=False`, so the help is no longer silently rendered monochrome — the output is a build artifact converted to HTML, not interactive terminal output ([#38](https://github.com/syn54x/mkdocs-typer2/issues/38)).
+
 ## [0.4.0] - 2026-06-16
 
 ### Added

--- a/src/mkdocs_typer2/termynal_render.py
+++ b/src/mkdocs_typer2/termynal_render.py
@@ -160,7 +160,10 @@ def _colored_help(command: click.core.Command, info_name: str, width: int = 80) 
     ``rich_format_help()`` hardcodes ``console = _get_rich_console()`` with no
     console/file parameter to inject (``CliRunner`` drops rich color, and the
     env-var knobs are import-time + process-global). So we swap that private
-    factory for a buffer-backed ``Console``.
+    factory for a buffer-backed ``Console``. That console sets
+    ``no_color=False`` so the captured help keeps its color even when
+    ``NO_COLOR`` is set in the environment (e.g. ReadTheDocs): this is a build
+    artifact converted to HTML, not interactive terminal output.
 
     If that private hook ever disappears (a future typer rename), we degrade
     safely: ``format_help`` runs with stdout redirected into the same buffer, so
@@ -184,6 +187,7 @@ def _colored_help(command: click.core.Command, info_name: str, width: int = 80) 
             lambda stderr=False: Console(  # noqa: ARG005
                 force_terminal=True,
                 color_system="standard",
+                no_color=False,
                 width=width,
                 file=buf,
                 highlight=False,

--- a/tests/test_termynal_render.py
+++ b/tests/test_termynal_render.py
@@ -36,6 +36,19 @@ def test_render_termynal_html_typer_colored_and_balanced():
     assert html.count("<span") == html.count("</span>")
 
 
+def test_render_termynal_html_keeps_color_when_no_color_set(monkeypatch):
+    # NO_COLOR in the build env (e.g. ReadTheDocs) must not strip color from the
+    # captured help: it is a build artifact converted to HTML, not interactive
+    # terminal output. rich's no_color defaults to ("NO_COLOR" in os.environ).
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    html = render_termynal_html(
+        "mkdocs_typer2.cli.cli", "mkdocs-typer2", TermynalOptions(subcommands=1)
+    )
+
+    assert 'style="color:' in html
+
+
 def test_render_termynal_html_root_only_by_default():
     html = render_termynal_html("mkdocs_typer2.cli.cli", "mkdocs-typer2")
 


### PR DESCRIPTION
Sorry for the churn. Only happened in ci on ReadTheDocs...

Closes #38.

## Problem

Termynal mode captures a Typer/Click app's `--help` with color by forcing a terminal in `termynal_render._colored_help`. The capture `Console` opts into a palette via `force_terminal=True` + `color_system="standard"`, but rich's `no_color` is a **separate** flag that defaults to `("NO_COLOR" in os.environ)`. In any build environment that sets `NO_COLOR` — **ReadTheDocs does** — every foreground color is stripped and the help renders monochrome. The build still succeeds, so the regression is silent. (`FORCE_COLOR=1` does not help: `NO_COLOR` takes precedence in rich.)

## Fix

Pass `no_color=False` to the capture `Console`. We've already declared intent to produce color via `force_terminal=True` + `color_system="standard"`; this makes that intent robust across build environments. The output here isn't interactive terminal text — it's ANSI converted to HTML spans for a docs page — so honoring `NO_COLOR` was a category error. The rationale lives in the `_colored_help` docstring.

## Tests

Adds `test_render_termynal_html_keeps_color_when_no_color_set`, which sets `NO_COLOR=1` and asserts color spans survive. Verified it fails without the fix and passes with it. Full termynal suite passes; `ruff format --check` and `ruff check` are clean.

A `[Unreleased] → Fixed` CHANGELOG entry is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)