### PR TITLE
chore: release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-17
+
 ### Fixed
 
 - Termynal mode now keeps its colors when `NO_COLOR` is set in the build environment (e.g. ReadTheDocs). The capture `Console` passes `no_color=False`, so the help is no longer silently rendered monochrome — the output is a build artifact converted to HTML, not interactive terminal output ([#38](https://github.com/syn54x/mkdocs-typer2/issues/38)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-typer2"
-version = "0.4.0"
+version = "0.4.1"
 description = "Typer CLI docs for MkDocs (optional) and Zensical via Python-Markdown"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare **0.4.1** for release:

- Bump `version` in `pyproject.toml` to `0.4.1`
- Document the termynal `NO_COLOR` fix merged since `0.4.0` in `CHANGELOG.md`

## Changes in 0.4.1

- **Fixed:** Termynal mode keeps colors when `NO_COLOR` is set in the build environment (e.g. ReadTheDocs) ([#39](https://github.com/syn54x/mkdocs-typer2/pull/39), [#38](https://github.com/syn54x/mkdocs-typer2/issues/38))

## After merge

1. Create GitHub Release `v0.4.1` (publish) to trigger PyPI upload via `publish.yml`
2. Docs site updates automatically on merge to `main`

## Test plan

- [x] Changelog and version bump only
- [x] `uv run pytest` passes locally (109 tests)

Made with [Cursor](https://cursor.com)